### PR TITLE
fix: release stale TRDIR lock after CreateObject

### DIFF
--- a/adt/object.go
+++ b/adt/object.go
@@ -130,7 +130,20 @@ func (c *httpClient) CreateObject(ctx context.Context, objectType, name, package
 				"On older ECC systems, create DDIC objects via transaction SE11", ot)
 		}
 	}
-	return checkResponse(resp)
+	if err := checkResponse(resp); err != nil {
+		return err
+	}
+
+	// SAP leaves a TRDIR ENQUEUE lock after creating an object.  This lock
+	// is invisible to the MCP lock map and blocks the next set_source /
+	// patch_source call with a 423.  Clear it by cycling through lock+unlock
+	// on the newly created object URI.  See mcp-server-abap#282.
+	objectURI := info.endpoint + "/" + strings.ToLower(name)
+	if handle, lockErr := c.LockObject(ctx, objectURI); lockErr == nil {
+		_ = c.UnlockObject(ctx, objectURI, handle)
+	}
+
+	return nil
 }
 
 func (c *httpClient) CreateFunctionModule(ctx context.Context, groupName, moduleName, description, packageName, transport string) error {

--- a/adt/object_test.go
+++ b/adt/object_test.go
@@ -20,6 +20,16 @@ func TestCreateObjectProgram(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
+		// Lock/unlock calls after create — return a dummy handle.
+		if strings.Contains(r.URL.RawQuery, "_action=LOCK") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("DUMMYHANDLE"))
+			return
+		}
+		if strings.Contains(r.URL.RawQuery, "_action=UNLOCK") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		gotPath = r.URL.Path
 		gotMethod = r.Method
 		w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
## Summary

`CreateObject` triggers a TRDIR ENQUEUE on the SAP server that is not tracked by the ADT client. This blocks the immediately following `set_source` / `patch_source` call with HTTP 423 ("User X is currently editing ..."), making the natural `create → write → activate` workflow dead-end at step 2.

Fix: after a successful POST, cycle lock+unlock on the freshly created object URI to clear the stale ENQUEUE.

Fixes Hochfrequenz/mcp-server-abap#282

## Test plan

- [x] `TestCreateObjectProgram` updated to handle lock/unlock requests
- [x] `go test ./...` all passing
- [ ] Integration test: `create_object` → `patch_source` → `activate` on S4 (needs live system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)