### PR TITLE
fix(#12): adopt 3-step ATC flow to fix R/3 500

### DIFF
--- a/adt/atc.go
+++ b/adt/atc.go
@@ -66,8 +66,9 @@ func (c *httpClient) GetATCCustomizing(ctx context.Context) (*ATCCustomizingResu
 //
 // The earlier 2-step shortcut (POST /runs with worklistId="0000000000",
 // checkVariant in body) returned HTTP 500 with empty body on R/3 — see
-// adtler#12. The 3-step flow is the one Eclipse ADT uses and works on
-// both R/3 and S/4.
+// adtler#12. The 3-step shape was observed in the abap-adt-api reference
+// implementation (src/api/atc.ts) and verified against the SAP ADT REST
+// API on both R/3 and S/4.
 //
 // If checkVariant is empty, "DEFAULT" is used. Callers on S/4 should pass
 // their site-specific variant explicitly.
@@ -130,7 +131,8 @@ func (c *httpClient) createATCWorklist(ctx context.Context, checkVariant string)
 // triggerATCRun performs step 2: posts the object references to the runs
 // endpoint, scoped to worklistID. SAP echoes back the worklist ID (and a
 // timestamp) in a <worklistRun> envelope; if the response carries a
-// non-empty ID, that ID supersedes the input.
+// non-empty ID, that ID supersedes the input (same supersession rule
+// observed in abap-adt-api).
 func (c *httpClient) triggerATCRun(ctx context.Context, worklistID string, objectURIs []string) (string, error) {
 	body := buildATCRunBody(objectURIs)
 

--- a/adt/atc.go
+++ b/adt/atc.go
@@ -6,10 +6,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Hochfrequenz/adtler/adt/adtxml"
 )
+
+// defaultATCCheckVariant is used when the caller passes an empty variant.
+// SAP R/3's standard ATC check variant is "DEFAULT" (also reported by
+// GetATCCustomizing on R/3). S/4 callers should pass their site-specific
+// variant explicitly (often "ZCB_CLEAN_ABAP_1") — DEFAULT may produce
+// different findings on S/4 than the system default.
+const defaultATCCheckVariant = "DEFAULT"
 
 func (c *httpClient) GetATCCustomizing(ctx context.Context) (*ATCCustomizingResult, error) {
 	resp, err := c.doRead(ctx, "/sap/bc/adt/atc/customizing", map[string]string{
@@ -45,42 +53,95 @@ func (c *httpClient) GetATCCustomizing(ctx context.Context) (*ATCCustomizingResu
 	return result, nil
 }
 
+// RunATCCheck runs an ATC check against the given object URIs. It implements
+// the canonical 3-step Eclipse ADT flow:
+//
+//  1. POST /sap/bc/adt/atc/worklists?checkVariant={variant} — creates a
+//     worklist seeded with the requested check variant. The response body
+//     is the worklist ID as plain text.
+//  2. POST /sap/bc/adt/atc/runs?worklistId={id} — triggers the actual run.
+//     The body carries the object references but no longer carries
+//     checkVariant (it's already established on the worklist).
+//  3. GET /sap/bc/adt/atc/worklists/{id} — fetches findings.
+//
+// The earlier 2-step shortcut (POST /runs with worklistId="0000000000",
+// checkVariant in body) returned HTTP 500 with empty body on R/3 — see
+// adtler#12. The 3-step flow matches what abap-adt-api / Eclipse ADT do
+// and works on both R/3 and S/4.
+//
+// If checkVariant is empty, "DEFAULT" is used. Callers on S/4 should pass
+// their site-specific variant explicitly.
 func (c *httpClient) RunATCCheck(ctx context.Context, objectURIs []string, checkVariant string) (*ATCResult, error) {
-	// Build object references XML. Escape URIs to prevent XML injection.
-	var refs strings.Builder
-	for _, uri := range objectURIs {
-		var escaped strings.Builder
-		_ = xml.EscapeText(&escaped, []byte(uri))
-		fmt.Fprintf(&refs, `<adtcore:objectReference adtcore:uri="%s"/>`, escaped.String())
+	if checkVariant == "" {
+		checkVariant = defaultATCCheckVariant
 	}
 
-	variantAttr := ""
-	if checkVariant != "" {
-		var escaped strings.Builder
-		_ = xml.EscapeText(&escaped, []byte(checkVariant))
-		variantAttr = fmt.Sprintf(` checkVariant="%s"`, escaped.String())
-	}
-
-	body := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>`+
-		`<atc:run xmlns:atc="http://www.sap.com/adt/atc" `+
-		`xmlns:adtcore="http://www.sap.com/adt/core" maximumVerdicts="100"%s>`+
-		`<objectSets>`+
-		`<objectSet kind="inclusive">`+
-		`<adtcore:objectReferences>%s</adtcore:objectReferences>`+
-		`</objectSet>`+
-		`</objectSets>`+
-		`</atc:run>`, variantAttr, refs.String())
-
-	// Step 1: Trigger ATC run with a worklist to collect results.
-	const worklistID = "0000000000"
 	if err := c.ensureCSRF(ctx); err != nil {
 		return nil, fmt.Errorf("RunATCCheck: %w", err)
 	}
+
+	// Step 1: Create a worklist for this variant. SAP returns the worklist
+	// ID as plain text in the response body.
+	worklistID, err := c.createATCWorklist(ctx, checkVariant)
+	if err != nil {
+		return nil, fmt.Errorf("RunATCCheck: %w", err)
+	}
+
+	// Step 2: Trigger the run, scoping it to the requested object URIs.
+	worklistID, err = c.triggerATCRun(ctx, worklistID, objectURIs)
+	if err != nil {
+		return nil, fmt.Errorf("RunATCCheck: %w", err)
+	}
+
+	// Step 3: Fetch the resulting findings.
+	return c.fetchATCWorklist(ctx, worklistID)
+}
+
+// createATCWorklist performs step 1 of the ATC flow and returns the
+// SAP-assigned worklist ID. The response body is plain text.
+func (c *httpClient) createATCWorklist(ctx context.Context, checkVariant string) (string, error) {
+	q := url.Values{}
+	q.Set("checkVariant", checkVariant)
+	resp, err := c.doMutate(ctx, http.MethodPost,
+		"/sap/bc/adt/atc/worklists?"+q.Encode(),
+		nil,
+		map[string]string{
+			"Accept": "text/plain",
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("create worklist: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if err := checkResponse(resp); err != nil {
+		return "", fmt.Errorf("create worklist: %w", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("create worklist reading body: %w", err)
+	}
+	id := strings.TrimSpace(string(body))
+	if id == "" {
+		return "", fmt.Errorf("create worklist: SAP returned empty worklist ID")
+	}
+	return id, nil
+}
+
+// triggerATCRun performs step 2: posts the object references to the runs
+// endpoint, scoped to worklistID. SAP echoes back the worklist ID (and a
+// timestamp) in a <worklistRun> envelope; if the response carries a
+// non-empty ID, that ID supersedes the input (matching abap-adt-api).
+func (c *httpClient) triggerATCRun(ctx context.Context, worklistID string, objectURIs []string) (string, error) {
+	body := buildATCRunBody(objectURIs)
+
 	ct := c.NegotiateContentType("/sap/bc/adt/atc/runs",
 		[]string{"application/vnd.sap.adt.atc.runs.v1+xml", "application/xml"},
 		"application/xml")
+
+	q := url.Values{}
+	q.Set("worklistId", worklistID)
 	resp, err := c.doMutate(ctx, http.MethodPost,
-		"/sap/bc/adt/atc/runs?clientWait=false&worklistId="+worklistID,
+		"/sap/bc/adt/atc/runs?"+q.Encode(),
 		strings.NewReader(body),
 		map[string]string{
 			"Content-Type": ct,
@@ -88,32 +149,44 @@ func (c *httpClient) RunATCCheck(ctx context.Context, objectURIs []string, check
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("RunATCCheck: %w", err)
+		return "", fmt.Errorf("trigger run: %w", err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if err := checkResponse(resp); err != nil {
-		return nil, err
+		return "", fmt.Errorf("trigger run: %w", err)
 	}
 
-	// Step 2: Fetch worklist results.
-	wlResp, err := c.doRead(ctx, "/sap/bc/adt/atc/worklists/"+worklistID, map[string]string{
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("trigger run reading body: %w", err)
+	}
+	var run adtxml.ATCWorklistRun
+	if err := xml.Unmarshal(respBody, &run); err == nil && run.WorklistID != "" {
+		return run.WorklistID, nil
+	}
+	return worklistID, nil
+}
+
+// fetchATCWorklist performs step 3: GETs the findings for worklistID.
+func (c *httpClient) fetchATCWorklist(ctx context.Context, worklistID string) (*ATCResult, error) {
+	resp, err := c.doRead(ctx, "/sap/bc/adt/atc/worklists/"+worklistID, map[string]string{
 		"Accept": "application/atc.worklist.v1+xml",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("RunATCCheck fetching worklist: %w", err)
 	}
-	defer func() { _ = wlResp.Body.Close() }()
-	if err := checkResponse(wlResp); err != nil {
+	defer func() { _ = resp.Body.Close() }()
+	if err := checkResponse(resp); err != nil {
 		return nil, err
 	}
 
-	wlData, err := io.ReadAll(wlResp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("RunATCCheck reading worklist: %w", err)
 	}
 
 	var worklist adtxml.ATCWorklist
-	if err := xml.Unmarshal(wlData, &worklist); err != nil {
+	if err := xml.Unmarshal(data, &worklist); err != nil {
 		return nil, fmt.Errorf("RunATCCheck parsing worklist: %w", err)
 	}
 
@@ -131,4 +204,25 @@ func (c *httpClient) RunATCCheck(ctx context.Context, objectURIs []string, check
 		}
 	}
 	return result, nil
+}
+
+// buildATCRunBody builds the XML body posted to /sap/bc/adt/atc/runs.
+// The variant is no longer carried here — it is established on the
+// worklist by createATCWorklist.
+func buildATCRunBody(objectURIs []string) string {
+	var refs strings.Builder
+	for _, uri := range objectURIs {
+		var escaped strings.Builder
+		_ = xml.EscapeText(&escaped, []byte(uri))
+		fmt.Fprintf(&refs, `<adtcore:objectReference adtcore:uri="%s"/>`, escaped.String())
+	}
+	return `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<atc:run xmlns:atc="http://www.sap.com/adt/atc" ` +
+		`xmlns:adtcore="http://www.sap.com/adt/core" maximumVerdicts="100">` +
+		`<objectSets>` +
+		`<objectSet kind="inclusive">` +
+		`<adtcore:objectReferences>` + refs.String() + `</adtcore:objectReferences>` +
+		`</objectSet>` +
+		`</objectSets>` +
+		`</atc:run>`
 }

--- a/adt/atc.go
+++ b/adt/atc.go
@@ -66,8 +66,8 @@ func (c *httpClient) GetATCCustomizing(ctx context.Context) (*ATCCustomizingResu
 //
 // The earlier 2-step shortcut (POST /runs with worklistId="0000000000",
 // checkVariant in body) returned HTTP 500 with empty body on R/3 — see
-// adtler#12. The 3-step flow matches what abap-adt-api / Eclipse ADT do
-// and works on both R/3 and S/4.
+// adtler#12. The 3-step flow is the one Eclipse ADT uses and works on
+// both R/3 and S/4.
 //
 // If checkVariant is empty, "DEFAULT" is used. Callers on S/4 should pass
 // their site-specific variant explicitly.
@@ -130,7 +130,7 @@ func (c *httpClient) createATCWorklist(ctx context.Context, checkVariant string)
 // triggerATCRun performs step 2: posts the object references to the runs
 // endpoint, scoped to worklistID. SAP echoes back the worklist ID (and a
 // timestamp) in a <worklistRun> envelope; if the response carries a
-// non-empty ID, that ID supersedes the input (matching abap-adt-api).
+// non-empty ID, that ID supersedes the input.
 func (c *httpClient) triggerATCRun(ctx context.Context, worklistID string, objectURIs []string) (string, error) {
 	body := buildATCRunBody(objectURIs)
 

--- a/adt/atc_discovery_integration_test.go
+++ b/adt/atc_discovery_integration_test.go
@@ -9,19 +9,24 @@ import (
 	"time"
 )
 
-// TestRunATCCheck_DiscoveryDriven_Integration verifies that after the
-// discovery-first content-negotiation refactor (adtler#35), RunATCCheck
-// still succeeds end-to-end against both R/3 and S/4.
+// TestRunATCCheck_DiscoveryDriven_Integration verifies that RunATCCheck
+// succeeds end-to-end against both R/3 and S/4 using the canonical 3-step
+// Eclipse-style flow:
 //
-// Historically RunATCCheck on R/3 returned HTTP 500 because the client sent
-// a hardcoded Content-Type that R/3 did not accept (adtler#12). With the
-// discovery-driven transport, the Content-Type is negotiated from the ATC
-// collection's advertised accept types, which should make the call succeed
-// on R/3 as well as S/4.
+//  1. POST /sap/bc/adt/atc/worklists?checkVariant=DEFAULT (text/plain)
+//  2. POST /sap/bc/adt/atc/runs?worklistId={id}            (XML body)
+//  3. GET  /sap/bc/adt/atc/worklists/{id}                  (findings)
+//
+// Historically RunATCCheck on R/3 returned HTTP 500 with empty body
+// (adtler#12). The earlier discovery-first content-negotiation refactor
+// (adtler#35) did not fix this. Root cause: the previous 2-step shortcut
+// posted /runs with a placeholder worklistId="0000000000" that R/3 does
+// not accept. The 3-step flow creates a real worklist first, matching
+// abap-adt-api / Eclipse ADT, and works on both R/3 and S/4.
 //
 // Uses eachSystem so a single test function validates behaviour against
-// every whitelisted SAP system (R/3 and S/4) in one run. On R/3 this may
-// close adtler#12; on S/4 it is a regression guard.
+// every whitelisted SAP system (R/3 and S/4) in one run. Closes adtler#12
+// when green on R/3.
 func TestRunATCCheck_DiscoveryDriven_Integration(t *testing.T) {
 	ctx := context.Background()
 	for _, sys := range eachSystem(t) {

--- a/adt/atc_discovery_integration_test.go
+++ b/adt/atc_discovery_integration_test.go
@@ -21,8 +21,8 @@ import (
 // (adtler#12). The earlier discovery-first content-negotiation refactor
 // (adtler#35) did not fix this. Root cause: the previous 2-step shortcut
 // posted /runs with a placeholder worklistId="0000000000" that R/3 does
-// not accept. The 3-step flow creates a real worklist first, matching
-// abap-adt-api / Eclipse ADT, and works on both R/3 and S/4.
+// not accept. The 3-step flow creates a real worklist first and works on
+// both R/3 and S/4.
 //
 // Uses eachSystem so a single test function validates behaviour against
 // every whitelisted SAP system (R/3 and S/4) in one run. Closes adtler#12

--- a/adt/atc_discovery_integration_test.go
+++ b/adt/atc_discovery_integration_test.go
@@ -21,8 +21,8 @@ import (
 // (adtler#12). The earlier discovery-first content-negotiation refactor
 // (adtler#35) did not fix this. Root cause: the previous 2-step shortcut
 // posted /runs with a placeholder worklistId="0000000000" that R/3 does
-// not accept. The 3-step flow creates a real worklist first and works on
-// both R/3 and S/4.
+// not accept. The 3-step shape was observed in the abap-adt-api reference
+// implementation; this integration test verifies it on both R/3 and S/4.
 //
 // Uses eachSystem so a single test function validates behaviour against
 // every whitelisted SAP system (R/3 and S/4) in one run. Closes adtler#12

--- a/adt/atc_test.go
+++ b/adt/atc_test.go
@@ -145,8 +145,8 @@ func TestRunATCCheck_CreatesWorklistBeforeRun(t *testing.T) {
 }
 
 // TestRunATCCheck_WorklistsPOSTUsesCheckVariantQuery verifies the variant is
-// passed on the /worklists URL query (matching abap-adt-api / Eclipse ADT),
-// not in the /runs body.
+// passed on the /worklists URL query (the SAP ADT contract), not in the
+// /runs body.
 func TestRunATCCheck_WorklistsPOSTUsesCheckVariantQuery(t *testing.T) {
 	cap := &atcMockCapture{}
 	srv := newATCMock(t, cap)
@@ -168,9 +168,9 @@ func TestRunATCCheck_WorklistsPOSTUsesCheckVariantQuery(t *testing.T) {
 	}
 }
 
-// TestRunATCCheck_WorklistsPOSTSendsTextPlainAccept matches abap-adt-api,
-// which sets Accept: text/plain because the worklist creation response is
-// a plain-text worklist ID.
+// TestRunATCCheck_WorklistsPOSTSendsTextPlainAccept — the worklist
+// creation response is a plain-text worklist ID, so the request must
+// advertise Accept: text/plain.
 func TestRunATCCheck_WorklistsPOSTSendsTextPlainAccept(t *testing.T) {
 	cap := &atcMockCapture{}
 	srv := newATCMock(t, cap)

--- a/adt/atc_test.go
+++ b/adt/atc_test.go
@@ -2,91 +2,355 @@ package adt_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Hochfrequenz/adtler/adt"
 	sapmcpconfig "github.com/Hochfrequenz/sap-mcp-config"
 )
 
+const (
+	atcWorklistsPath = "/sap/bc/adt/atc/worklists"
+	atcRunsPath      = "/sap/bc/adt/atc/runs"
+)
+
+// atcMockServer simulates the canonical 3-step ATC flow:
+//  1. POST /sap/bc/adt/atc/worklists?checkVariant=...   → returns plain-text worklist ID
+//  2. POST /sap/bc/adt/atc/runs?worklistId=...           → returns <worklistRun>
+//  3. GET  /sap/bc/adt/atc/worklists/{id}                → returns empty <worklist>
+//
+// All requests are recorded under c.mu so individual tests can assert on
+// order, paths, query strings, headers, and bodies.
+type atcMockCapture struct {
+	mu sync.Mutex
+
+	// Order of meaningful (non-CSRF) calls received.
+	calls []string
+
+	// Worklists POST.
+	worklistsCalled       bool
+	worklistsQuery        string
+	worklistsAcceptHeader string
+
+	// Runs POST.
+	runsQuery       string
+	runsContentType string
+	runsBody        string
+
+	// Worklist GET.
+	worklistGetPath string
+
+	// Server-side responses (configurable per-test).
+	worklistID       string // returned by the worklists POST
+	runResponseID    string // worklistRun/@id in the runs response (empty = same as worklistID)
+	discoveryXML     string
+	worklistFindings string // body returned by the worklist GET
+}
+
+func newATCMock(t *testing.T, c *atcMockCapture) *httptest.Server {
+	t.Helper()
+
+	if c.worklistID == "" {
+		c.worklistID = "WL000000000000000001"
+	}
+	if c.worklistFindings == "" {
+		c.worklistFindings = `<?xml version="1.0"?><atcworklist:worklist xmlns:atcworklist="http://www.sap.com/adt/atc/worklist" atcworklist:id="` + c.worklistID + `"/>`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		switch {
+		case r.URL.Path == csrfEndpoint:
+			w.Header().Set("X-CSRF-Token", "tok")
+			w.WriteHeader(http.StatusOK)
+			if c.discoveryXML != "" {
+				_, _ = w.Write([]byte(c.discoveryXML))
+			}
+
+		case r.Method == http.MethodPost && r.URL.Path == atcWorklistsPath:
+			c.calls = append(c.calls, "worklists POST")
+			c.worklistsCalled = true
+			c.worklistsQuery = r.URL.RawQuery
+			c.worklistsAcceptHeader = r.Header.Get("Accept")
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(c.worklistID))
+
+		case r.Method == http.MethodPost && r.URL.Path == atcRunsPath:
+			c.calls = append(c.calls, "runs POST")
+			c.runsQuery = r.URL.RawQuery
+			c.runsContentType = r.Header.Get("Content-Type")
+			body, _ := io.ReadAll(r.Body)
+			c.runsBody = string(body)
+			id := c.runResponseID
+			if id == "" {
+				id = c.worklistID
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><atc:worklistRun xmlns:atc="http://www.sap.com/adt/atc" atc:worklistId="` + id + `" atc:worklistTimestamp="2026-04-27T12:00:00Z"/>`))
+
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, atcWorklistsPath+"/"):
+			c.calls = append(c.calls, "worklist GET")
+			c.worklistGetPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(c.worklistFindings))
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newATCClient(srv *httptest.Server) adt.Client {
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	return adt.NewClient(cfg)
+}
+
+// TestRunATCCheck_CreatesWorklistBeforeRun verifies the canonical 3-step
+// flow: POST /worklists must precede POST /runs, which must precede the
+// findings GET. This is the difference that fixes adtler#12 — R/3 returns
+// 500 on a /runs POST that references a non-existent worklist ID.
+func TestRunATCCheck_CreatesWorklistBeforeRun(t *testing.T) {
+	cap := &atcMockCapture{}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
+
+	_, err := client.RunATCCheck(context.Background(),
+		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "DEFAULT")
+	if err != nil {
+		t.Fatalf("RunATCCheck: %v", err)
+	}
+
+	want := []string{"worklists POST", "runs POST", "worklist GET"}
+	cap.mu.Lock()
+	got := append([]string(nil), cap.calls...)
+	cap.mu.Unlock()
+	if len(got) != len(want) {
+		t.Fatalf("call order: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("call[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestRunATCCheck_WorklistsPOSTUsesCheckVariantQuery verifies the variant is
+// passed on the /worklists URL query (matching abap-adt-api / Eclipse ADT),
+// not in the /runs body.
+func TestRunATCCheck_WorklistsPOSTUsesCheckVariantQuery(t *testing.T) {
+	cap := &atcMockCapture{}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
+
+	_, err := client.RunATCCheck(context.Background(),
+		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "MY_VARIANT")
+	if err != nil {
+		t.Fatalf("RunATCCheck: %v", err)
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if !cap.worklistsCalled {
+		t.Fatalf("expected POST %s, was not called", atcWorklistsPath)
+	}
+	if got, want := cap.worklistsQuery, "checkVariant=MY_VARIANT"; got != want {
+		t.Errorf("worklists query: got %q, want %q", got, want)
+	}
+}
+
+// TestRunATCCheck_WorklistsPOSTSendsTextPlainAccept matches abap-adt-api,
+// which sets Accept: text/plain because the worklist creation response is
+// a plain-text worklist ID.
+func TestRunATCCheck_WorklistsPOSTSendsTextPlainAccept(t *testing.T) {
+	cap := &atcMockCapture{}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
+
+	_, err := client.RunATCCheck(context.Background(),
+		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "DEFAULT")
+	if err != nil {
+		t.Fatalf("RunATCCheck: %v", err)
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if got, want := cap.worklistsAcceptHeader, "text/plain"; got != want {
+		t.Errorf("worklists Accept: got %q, want %q", got, want)
+	}
+}
+
+// TestRunATCCheck_RunsBodyOmitsCheckVariantAttribute — once the variant is
+// established by the worklist creation, the /runs body must not carry
+// checkVariant. Sending it can confuse R/3.
+func TestRunATCCheck_RunsBodyOmitsCheckVariantAttribute(t *testing.T) {
+	cap := &atcMockCapture{}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
+
+	_, err := client.RunATCCheck(context.Background(),
+		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "DEFAULT")
+	if err != nil {
+		t.Fatalf("RunATCCheck: %v", err)
+	}
+
+	cap.mu.Lock()
+	body := cap.runsBody
+	cap.mu.Unlock()
+	if strings.Contains(body, "checkVariant") {
+		t.Errorf("runs body must not contain checkVariant; got: %s", body)
+	}
+}
+
+// TestRunATCCheck_PropagatesWorklistIDFromWorklistsResponse — the ID returned
+// from the /worklists POST must be used as worklistId on the /runs URL and
+// in the findings GET path.
+func TestRunATCCheck_PropagatesWorklistIDFromWorklistsResponse(t *testing.T) {
+	cap := &atcMockCapture{worklistID: "WLABC123"}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
+
+	_, err := client.RunATCCheck(context.Background(),
+		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "DEFAULT")
+	if err != nil {
+		t.Fatalf("RunATCCheck: %v", err)
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if got, want := cap.runsQuery, "worklistId=WLABC123"; got != want {
+		t.Errorf("runs query: got %q, want %q", got, want)
+	}
+	if got, want := cap.worklistGetPath, atcWorklistsPath+"/WLABC123"; got != want {
+		t.Errorf("worklist GET path: got %q, want %q", got, want)
+	}
+}
+
+// TestRunATCCheck_PrefersWorklistIDFromRunsResponse — if the /runs response
+// carries a different worklistId in the <worklistRun> envelope, that ID
+// (rather than the one from step 1) is used to fetch findings.
+func TestRunATCCheck_PrefersWorklistIDFromRunsResponse(t *testing.T) {
+	cap := &atcMockCapture{
+		worklistID:    "WL_FROM_STEP1",
+		runResponseID: "WL_FROM_STEP2",
+	}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
+
+	_, err := client.RunATCCheck(context.Background(),
+		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "DEFAULT")
+	if err != nil {
+		t.Fatalf("RunATCCheck: %v", err)
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if got, want := cap.worklistGetPath, atcWorklistsPath+"/WL_FROM_STEP2"; got != want {
+		t.Errorf("worklist GET path: got %q, want %q", got, want)
+	}
+}
+
+// TestRunATCCheck_DefaultsVariantToDEFAULT — empty caller variant maps to
+// "DEFAULT" on the worklists URL. Avoids GetATCCustomizing (which has its
+// own session-state issue, adtler#44).
+func TestRunATCCheck_DefaultsVariantToDEFAULT(t *testing.T) {
+	cap := &atcMockCapture{}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
+
+	_, err := client.RunATCCheck(context.Background(),
+		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "")
+	if err != nil {
+		t.Fatalf("RunATCCheck: %v", err)
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if got, want := cap.worklistsQuery, "checkVariant=DEFAULT"; got != want {
+		t.Errorf("worklists query for empty variant: got %q, want %q", got, want)
+	}
+}
+
+// TestRunATCCheck_PercentEncodesCheckVariant — variants with characters that
+// need URL escaping (spaces, slashes) must be safely encoded on the
+// worklists URL. SAP variant names are typically ALL_CAPS_UNDERSCORES, but
+// the client must not corrupt unusual values.
+func TestRunATCCheck_PercentEncodesCheckVariant(t *testing.T) {
+	cap := &atcMockCapture{}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
+
+	_, err := client.RunATCCheck(context.Background(),
+		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "MY VARIANT/X")
+	if err != nil {
+		t.Fatalf("RunATCCheck: %v", err)
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	want := "checkVariant=MY+VARIANT%2FX"
+	if got := cap.worklistsQuery; got != want {
+		t.Errorf("worklists query: got %q, want %q", got, want)
+	}
+}
+
+// TestRunATCCheck_UsesDiscoveryAdvertisedContentType — when discovery
+// advertises a vendor MIME type for /sap/bc/adt/atc/runs, that type drives
+// the runs POST Content-Type. Regression guard for the adtler#35 refactor.
 func TestRunATCCheck_UsesDiscoveryAdvertisedContentType(t *testing.T) {
-	discoveryXML := `<?xml version="1.0"?>
+	cap := &atcMockCapture{
+		discoveryXML: `<?xml version="1.0"?>
 <app:service xmlns:app="http://www.w3.org/2007/app">
   <app:workspace>
     <app:collection href="/sap/bc/adt/atc/runs">
       <app:accept>application/vnd.sap.adt.atc.runs.v1+xml</app:accept>
     </app:collection>
   </app:workspace>
-</app:service>`
-
-	var capturedCT string
-	worklistXML := `<?xml version="1.0"?><atcworklist:worklist xmlns:atcworklist="http://www.sap.com/adt/atc/worklist" atcworklist:id="0000000000"/>`
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == csrfEndpoint:
-			w.Header().Set("X-CSRF-Token", "tok")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(discoveryXML))
-		case r.Method == http.MethodPost && r.URL.Path == "/sap/bc/adt/atc/runs":
-			capturedCT = r.Header.Get("Content-Type")
-			w.WriteHeader(http.StatusOK)
-		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/sap/bc/adt/atc/worklists/"):
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(worklistXML))
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
-
-	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
-	client := adt.NewClient(cfg)
+</app:service>`,
+	}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
 
 	_, err := client.RunATCCheck(context.Background(),
 		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "DEFAULT")
 	if err != nil {
 		t.Fatalf("RunATCCheck: %v", err)
 	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
 	want := "application/vnd.sap.adt.atc.runs.v1+xml"
-	if capturedCT != want {
-		t.Errorf("Content-Type: got %q, want %q", capturedCT, want)
+	if cap.runsContentType != want {
+		t.Errorf("runs Content-Type: got %q, want %q", cap.runsContentType, want)
 	}
 }
 
+// TestRunATCCheck_FallbackContentTypeWhenDiscoveryEmpty — when discovery
+// has no entry for /sap/bc/adt/atc/runs, the runs POST falls back to
+// application/xml.
 func TestRunATCCheck_FallbackContentTypeWhenDiscoveryEmpty(t *testing.T) {
-	var capturedCT string
-	worklistXML := `<?xml version="1.0"?><atcworklist:worklist xmlns:atcworklist="http://www.sap.com/adt/atc/worklist" atcworklist:id="0000000000"/>`
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == csrfEndpoint:
-			w.Header().Set("X-CSRF-Token", "tok")
-			w.WriteHeader(http.StatusOK)
-			// Empty discovery body — no entries
-		case r.Method == http.MethodPost && r.URL.Path == "/sap/bc/adt/atc/runs":
-			capturedCT = r.Header.Get("Content-Type")
-			w.WriteHeader(http.StatusOK)
-		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/sap/bc/adt/atc/worklists/"):
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(worklistXML))
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
-
-	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
-	client := adt.NewClient(cfg)
+	cap := &atcMockCapture{}
+	srv := newATCMock(t, cap)
+	client := newATCClient(srv)
 
 	_, err := client.RunATCCheck(context.Background(),
 		[]string{"/sap/bc/adt/programs/programs/ZTEST"}, "DEFAULT")
 	if err != nil {
 		t.Fatalf("RunATCCheck: %v", err)
 	}
-	if capturedCT != "application/xml" {
-		t.Errorf("Content-Type fallback: got %q, want %q", capturedCT, "application/xml")
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if cap.runsContentType != "application/xml" {
+		t.Errorf("runs Content-Type fallback: got %q, want %q", cap.runsContentType, "application/xml")
 	}
 }

--- a/adt/atc_test.go
+++ b/adt/atc_test.go
@@ -145,8 +145,8 @@ func TestRunATCCheck_CreatesWorklistBeforeRun(t *testing.T) {
 }
 
 // TestRunATCCheck_WorklistsPOSTUsesCheckVariantQuery verifies the variant is
-// passed on the /worklists URL query (the SAP ADT contract), not in the
-// /runs body.
+// passed on the /worklists URL query (as observed in abap-adt-api), not in
+// the /runs body.
 func TestRunATCCheck_WorklistsPOSTUsesCheckVariantQuery(t *testing.T) {
 	cap := &atcMockCapture{}
 	srv := newATCMock(t, cap)
@@ -170,7 +170,7 @@ func TestRunATCCheck_WorklistsPOSTUsesCheckVariantQuery(t *testing.T) {
 
 // TestRunATCCheck_WorklistsPOSTSendsTextPlainAccept — the worklist
 // creation response is a plain-text worklist ID, so the request must
-// advertise Accept: text/plain.
+// advertise Accept: text/plain (as observed in abap-adt-api).
 func TestRunATCCheck_WorklistsPOSTSendsTextPlainAccept(t *testing.T) {
 	cap := &atcMockCapture{}
 	srv := newATCMock(t, cap)


### PR DESCRIPTION
## Summary

Closes #12. Consumer-side: Hochfrequenz/mcp-server-abap#288.

`RunATCCheck` previously used a 2-step shortcut — it posted to `/sap/bc/adt/atc/runs` with a placeholder `worklistId="0000000000"` and put `checkVariant` in the body. This worked on S/4 (silent auto-create) but returned HTTP 500 with empty body on R/3, which strictly requires a real worklist to exist before `/runs` is invoked.

This PR adopts the SAP ADT 3-step worklist flow — the shape was observed in the [abap-adt-api](https://github.com/marcellourbani/abap-adt-api) reference implementation (`src/api/atc.ts`) during investigation and verified end-to-end against real R/3 and S/4 systems. No code was copied; the Go implementation is independently written from observation of the wire protocol.

1. `POST /sap/bc/adt/atc/worklists?checkVariant={variant}` — `Accept: text/plain`, response body is the SAP-assigned worklist ID.
2. `POST /sap/bc/adt/atc/runs?worklistId={obtainedID}` — body no longer carries `checkVariant`. If the response carries a different ID in `<worklistRun>`, that ID supersedes the input.
3. `GET /sap/bc/adt/atc/worklists/{id}` — findings, unchanged shape.

Discovery-driven Content-Type negotiation for the `/runs` POST (adtler#35) is preserved.

## Why the previous attempt didn't fix this

PR #41 hypothesised that R/3 was rejecting the hardcoded `application/xml` Content-Type and tried to fix it via `NegotiateContentType`. As @hf-mrdachner reported on that PR, R/3's discovery doesn't advertise a vendor MIME for `/atc/runs`, so the negotiation falls back to the same `application/xml` the pre-refactor code sent — leaving the 500 in place. Root cause is the missing worklist creation step, not the Content-Type. The empty 500 body is consistent with R/3's ATC handler crashing before it can produce a diagnostic when handed a non-existent worklist ID.

## Behavior change

- Empty `checkVariant` now defaults to `"DEFAULT"` (R/3's system default). Previously the `checkVariant` attribute was simply omitted from the body. **S/4 callers should pass their site-specific variant explicitly** (e.g. `ZCB_CLEAN_ABAP_1`) — `DEFAULT` may produce different findings on S/4 than the system default.
- The deliberate choice **not** to auto-call `GetATCCustomizing` for an empty variant: that call triggers adtler#44 (session-state issue) on S/4 and adds an extra round-trip. Callers who need to discover their system variant can call `GetATCCustomizing` themselves.

## Test plan

- [x] `go test ./...` (unit) — all green; 8 new ATC tests cover call ordering, query strings, accept header, body shape (no `checkVariant`), worklist ID propagation through both responses, the `DEFAULT` fallback, and URL-encoding of variant names.
- [x] `go vet ./...` and `go vet -tags integration ./adt/...` — clean
- [x] `go build ./...` and `go build -tags integration ./adt/...` — clean
- [x] `golangci-lint run --enable dupl,goconst,gocyclo ./...` — 0 issues
- [x] `gofmt -l .` — clean
- [x] Integration: `TestRunATCCheck_DiscoveryDriven_Integration` on R/3 + S/4 — both PASS (results posted as PR comment)
- [x] Manual probe against an activated package-bound program on R/3 + S/4 (the production failure path of #12) — both PASS (results posted as PR comment)

## Files

- `adt/atc.go` — split `RunATCCheck` into `createATCWorklist` / `triggerATCRun` / `fetchATCWorklist` helpers; add `defaultATCCheckVariant` constant; reuse the existing `adtxml.ATCWorklistRun` struct (was declared but unused).
- `adt/atc_test.go` — 8 new tests + an `atcMockCapture` helper for the 3-step flow; existing Content-Type tests adapted to the new flow.
- `adt/atc_discovery_integration_test.go` — docstring updated; test surface unchanged (still creates a `$TMP` program, calls `RunATCCheck`, asserts no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)