### PR TITLE
docs: drop stale adtler#44 reference from ATC test docstring

### DIFF
--- a/adt/atc_test.go
+++ b/adt/atc_test.go
@@ -260,8 +260,9 @@ func TestRunATCCheck_PrefersWorklistIDFromRunsResponse(t *testing.T) {
 }
 
 // TestRunATCCheck_DefaultsVariantToDEFAULT — empty caller variant maps to
-// "DEFAULT" on the worklists URL. Avoids GetATCCustomizing (which has its
-// own session-state issue, adtler#44).
+// "DEFAULT" on the worklists URL. The fallback avoids an implicit
+// GetATCCustomizing round-trip; callers who need to discover their
+// system variant can call GetATCCustomizing themselves.
 func TestRunATCCheck_DefaultsVariantToDEFAULT(t *testing.T) {
 	cap := &atcMockCapture{}
 	srv := newATCMock(t, cap)


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #50. The 3-step ATC worklist flow merged in #50 incidentally fixed adtler#44 (`GetATCCustomizing` → `RunATCCheck` causing the second call to 500 on S/4). Verified by running the sequence end-to-end on the merged branch:

```
[hfq] systemCheckVariant="DEFAULT"
[hfq] RunATCCheck OK after customizing: worklist="00505694359E1FE190D74306EC62F81C", 1 findings
[s4u] systemCheckVariant="ZCB_CLEAN_ABAP_1"
[s4u] RunATCCheck OK after customizing: worklist="005056BA9BFB1FE190D7435D06545299", 1 findings
```

The brittle path that caused #44 (placeholder `worklistId` being session-state-sensitive after a customizing GET on S/4) is gone with the new flow.

This PR drops a now-stale reference to #44 in the `TestRunATCCheck_DefaultsVariantToDEFAULT` docstring (the design choice to default to `"DEFAULT"` instead of auto-fetching the system variant still stands — but the remaining justification is just "avoid an extra round-trip + keep the choice explicit", not the #44 session-state issue).

Closes #44 once the integration evidence is acknowledged.

## Test plan

- [x] `go test ./...` — green
- [x] No code change; docstring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)