### PR TITLE
fix(#8): pass source body to NavigateToDefinition

### DIFF
--- a/adt/client.go
+++ b/adt/client.go
@@ -57,7 +57,13 @@ type DocuClient interface {
 
 // NavigationClient resolves source references.
 type NavigationClient interface {
-	NavigateToDefinition(ctx context.Context, sourceURI string) (string, error)
+	// NavigateToDefinition resolves the symbol at the cursor position
+	// embedded in sourceURI (as `...#start=line,column`) to its definition.
+	// The source code that the cursor refers to must be passed in source —
+	// the SAP handler reads the body as plain text and uses it together
+	// with the position fragment to compute the navigation target. Passing
+	// the source the caller already has avoids a round-trip GetSource call.
+	NavigateToDefinition(ctx context.Context, sourceURI, source string) (string, error)
 }
 
 // SearchClient provides object discovery.

--- a/adt/custexport/export_test.go
+++ b/adt/custexport/export_test.go
@@ -152,7 +152,7 @@ func (m *mockClient) SetMessages(context.Context, string, string, []adt.Message)
 func (m *mockClient) SetTextElements(context.Context, string, []adt.TextSymbol, []adt.SelectionText, string, string) error {
 	panic("not implemented")
 }
-func (m *mockClient) NavigateToDefinition(context.Context, string) (string, error) {
+func (m *mockClient) NavigateToDefinition(context.Context, string, string) (string, error) {
 	panic("not implemented")
 }
 func (m *mockClient) Rename(context.Context, string, string, string) (*adt.RenameResult, error) {

--- a/adt/navigation.go
+++ b/adt/navigation.go
@@ -7,12 +7,21 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
-func (c *httpClient) NavigateToDefinition(ctx context.Context, sourceURI string) (string, error) {
+func (c *httpClient) NavigateToDefinition(ctx context.Context, sourceURI, source string) (string, error) {
+	// SAP handler CL_SEDI_ADT_RES_NAVIGATION->post reads the source text
+	// from the request body via get_handler_for_plain_text and combines it
+	// with the cursor position from the URI fragment to resolve the target.
+	// Without a body the navigation cannot run and the response stays empty,
+	// which earlier looked to callers like an "echo" of the input URI.
 	path := "/sap/bc/adt/navigation/target?uri=" + url.QueryEscape(sourceURI)
-	resp, err := c.doMutate(ctx, http.MethodPost, path, nil,
-		map[string]string{"Accept": "application/xml"})
+	resp, err := c.doMutate(ctx, http.MethodPost, path, strings.NewReader(source),
+		map[string]string{
+			"Content-Type": "text/plain; charset=utf-8",
+			"Accept":       "application/xml",
+		})
 	if err != nil {
 		return "", fmt.Errorf("NavigateToDefinition: %w", err)
 	}

--- a/adt/navigation_integration_test.go
+++ b/adt/navigation_integration_test.go
@@ -9,19 +9,19 @@ import (
 	"testing"
 )
 
-// TestNavigateToDefinition_Namespace_MultiSystem_Integration exercises
-// NavigateToDefinition against real SAP systems. The fix passes the source
-// code in the request body — without it the SAP handler
-// (CL_SEDI_ADT_RES_NAVIGATION) cannot resolve the cursor position and the
-// response stays empty, which earlier looked to callers like an "echo" of
-// the input URI.
+// TestNavigateToDefinition_MultiSystem_Integration exercises
+// NavigateToDefinition against real SAP systems. The fix posts the source
+// code as the request body — CL_SEDI_ADT_RES_NAVIGATION reads the body via
+// get_handler_for_plain_text and combines it with the cursor position from
+// the URI fragment to compute the target. Without the body the handler
+// returns an empty response, which earlier looked like an "echo" of the
+// input URI.
 //
-// The test:
-//   - Asserts the call does NOT error
-//   - Logs the resolved target so failures are diagnosable
-//   - Skips when the test report has no cross-reference for the cursor to
-//     land on (R/3 fixture is a bare REPORT)
-func TestNavigateToDefinition_Namespace_MultiSystem_Integration(t *testing.T) {
+// The test asserts that a clear cross-reference (cl_abap_unit_assert or
+// TYPE string) resolves to a *different* URI than the cursor position —
+// echoing back means the fix regressed. When no cross-reference exists in
+// the test fixture (the R/3 stub is a bare REPORT), the test skips.
+func TestNavigateToDefinition_MultiSystem_Integration(t *testing.T) {
 	ctx := context.Background()
 	for _, sys := range eachSystem(t) {
 		sys := sys
@@ -63,16 +63,14 @@ func TestNavigateToDefinition_Namespace_MultiSystem_Integration(t *testing.T) {
 
 			target, err := sys.Client.NavigateToDefinition(ctx, sourceURI, src.Source)
 			if err != nil {
-				t.Fatalf("[%s] NavigateToDefinition returned error: %v — "+
-					"namespace parsing may be broken", sys.Name, err)
+				t.Fatalf("[%s] NavigateToDefinition returned error: %v", sys.Name, err)
 			}
-
-			t.Logf("[%s] target: %s", sys.Name, target)
-			if target == sourceURI || target == "" {
-				t.Logf("[%s] endpoint echoed input (known SAP limitation per issue #8 investigation)", sys.Name)
-			} else {
-				t.Logf("[%s] endpoint returned a DIFFERENT target — navigation resolved!", sys.Name)
+			if target == "" || target == sourceURI {
+				t.Fatalf("[%s] endpoint echoed input (target=%q) — "+
+					"the body-as-source fix regressed; the SAP handler "+
+					"likely received an empty body", sys.Name, target)
 			}
+			t.Logf("[%s] resolved to %s", sys.Name, target)
 		})
 	}
 }

--- a/adt/navigation_namespace_integration_test.go
+++ b/adt/navigation_namespace_integration_test.go
@@ -10,17 +10,17 @@ import (
 )
 
 // TestNavigateToDefinition_Namespace_MultiSystem_Integration exercises
-// NavigateToDefinition against real SAP systems. The namespace parsing fix
-// in this PR ensures the adtcore:uri attribute is extracted correctly from
-// the namespaced XML response.
+// NavigateToDefinition against real SAP systems. The fix passes the source
+// code in the request body — without it the SAP handler
+// (CL_SEDI_ADT_RES_NAVIGATION) cannot resolve the cursor position and the
+// response stays empty, which earlier looked to callers like an "echo" of
+// the input URI.
 //
-// NOTE: from the Wave 2 investigation (issue #8), we know the endpoint
-// genuinely echoes the input position for many cursor positions — even
-// for clear cross-references like cl_abap_unit_assert. This is a SAP
-// endpoint limitation, not a parsing bug. The test therefore:
-//   - Asserts the call does NOT error (namespace parsing doesn't break it)
-//   - Logs whether the result is an echo or an actual navigation target
-//   - Does NOT hard-fail on echo (that's the known behaviour)
+// The test:
+//   - Asserts the call does NOT error
+//   - Logs the resolved target so failures are diagnosable
+//   - Skips when the test report has no cross-reference for the cursor to
+//     land on (R/3 fixture is a bare REPORT)
 func TestNavigateToDefinition_Namespace_MultiSystem_Integration(t *testing.T) {
 	ctx := context.Background()
 	for _, sys := range eachSystem(t) {
@@ -61,7 +61,7 @@ func TestNavigateToDefinition_Namespace_MultiSystem_Integration(t *testing.T) {
 				strconv.Itoa(navLine) + "," + strconv.Itoa(navCol)
 			t.Logf("[%s] navigating from %s", sys.Name, sourceURI)
 
-			target, err := sys.Client.NavigateToDefinition(ctx, sourceURI)
+			target, err := sys.Client.NavigateToDefinition(ctx, sourceURI, src.Source)
 			if err != nil {
 				t.Fatalf("[%s] NavigateToDefinition returned error: %v — "+
 					"namespace parsing may be broken", sys.Name, err)

--- a/adt/navigation_test.go
+++ b/adt/navigation_test.go
@@ -2,6 +2,7 @@ package adt_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestNavigateToDefinition(t *testing.T) {
+	const wantSource = "REPORT ztest.\nDATA cls TYPE REF TO zcl_target."
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == csrfEndpoint {
 			w.Header().Set("X-CSRF-Token", "token")
@@ -20,6 +22,13 @@ func TestNavigateToDefinition(t *testing.T) {
 		if r.URL.Path != "/sap/bc/adt/navigation/target" {
 			w.WriteHeader(http.StatusNotFound)
 			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != wantSource {
+			t.Errorf("body: got %q, want %q", string(body), wantSource)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+			t.Errorf("Content-Type: got %q", ct)
 		}
 		w.Header().Set("Content-Type", "application/xml")
 		w.WriteHeader(http.StatusOK)
@@ -35,7 +44,7 @@ func TestNavigateToDefinition(t *testing.T) {
 	client := adt.NewClient(cfg)
 
 	uri, err := client.NavigateToDefinition(context.Background(),
-		"/sap/bc/adt/programs/programs/ztest/source/main#start=5,8")
+		"/sap/bc/adt/programs/programs/ztest/source/main#start=5,8", wantSource)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/adt/registry.go
+++ b/adt/registry.go
@@ -110,8 +110,8 @@ func (r *ClientRegistry) SetMessages(ctx context.Context, messageClassName, etag
 func (r *ClientRegistry) SetTextElements(ctx context.Context, objectURI string, symbols []TextSymbol, selections []SelectionText, lockHandle, transport string) error {
 	return r.activeClient().SetTextElements(ctx, objectURI, symbols, selections, lockHandle, transport)
 }
-func (r *ClientRegistry) NavigateToDefinition(ctx context.Context, sourceURI string) (string, error) {
-	return r.activeClient().NavigateToDefinition(ctx, sourceURI)
+func (r *ClientRegistry) NavigateToDefinition(ctx context.Context, sourceURI, source string) (string, error) {
+	return r.activeClient().NavigateToDefinition(ctx, sourceURI, source)
 }
 func (r *ClientRegistry) GetTableFields(ctx context.Context, tableName string) ([]FieldInfo, error) {
 	return r.activeClient().GetTableFields(ctx, tableName)


### PR DESCRIPTION
## Summary

Closes #8.

`CL_SEDI_ADT_RES_NAVIGATION->post` reads the source via
`get_handler_for_plain_text` and combines it with the cursor position from the
URI fragment to resolve the navigation target. With a `nil` body the handler
cannot run, so `target_wb_request` stays initial and the response body never
gets set — which to callers looked like the endpoint was *echoing* the input
URI.

This PR adds a `source` parameter to `NavigateToDefinition` and posts the text
as `text/plain; charset=utf-8`. The caller already has the source in hand for
the cursor it is referring to, so this is cheaper than fetching it again
internally.

**Breaking change** in `adt.NavigationClient`:

```go
// before
NavigateToDefinition(ctx context.Context, sourceURI string) (string, error)
// after
NavigateToDefinition(ctx context.Context, sourceURI, source string) (string, error)
```

Mock (`custexport/export_test.go`), registry forwarder, and the httptest +
integration tests are updated.

## Test plan

- [x] `go test ./...` (unit, including updated httptest mock + body assertion)
- [x] `go vet -tags integration ./adt/...`
- [x] `go test -tags=integration -run TestNavigateToDefinition_Namespace_MultiSystem_Integration ./adt/` against `s4u` — cursor on `cl_abap_unit_assert` resolves to `/sap/bc/adt/oo/classes/cl_abap_unit_assert/source/main#start=2,6`
- [ ] R/3 (`hfq`) — test fixture is a bare REPORT with no cross-reference, so the integration test skips. R/3 verification deferred to local-agent run with a richer test source.
- [ ] CI green (lint, multi-Go-version unit tests, coverage, CodeQL)
- [ ] Local agent re-runs integration tests with `needs:integration-test` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)