### PR TITLE
fix: send correct Accept header for VIT object types (#72)

### DIFF
--- a/adt/repository.go
+++ b/adt/repository.go
@@ -71,6 +71,7 @@ var objectTypeAcceptHeaders = map[string]string{
 	"/sap/bc/adt/packages":               "application/vnd.sap.adt.packages.v2+xml",
 	"/sap/bc/adt/bo/behaviordefinitions": "application/vnd.sap.adt.blues.v1+xml",
 	"/sap/bc/adt/acm/dcl/sources":        "application/vnd.sap.adt.dclSource+xml",
+	"/sap/bc/adt/vit/wb/object_type":     vitObjectPropertiesContentType,
 }
 
 // fugrIncludeContentType is the vendor MIME type S/4 requires for function
@@ -79,6 +80,12 @@ var objectTypeAcceptHeaders = map[string]string{
 // (functions.groups.v3+xml) which S/4 rejects with HTTP 406 for include
 // URIs. See adtler#17 / mcp-server-abap#296.
 const fugrIncludeContentType = "application/vnd.sap.adt.functions.fincludes.v2+xml"
+
+// vitObjectPropertiesContentType is the vendor MIME type required by SAP for
+// all VIT (Visual IT Tools) object types whose ADT URIs start with
+// /sap/bc/adt/vit/wb/object_type/. SAP advertises this type in the 406
+// response when the wrong Accept header is sent. See adtler#72.
+const vitObjectPropertiesContentType = "application/vnd.sap.adt.basic.object.properties+xml"
 
 // acceptHeaderForURI returns the best Accept header for a given object URI.
 // It first checks the ADT discovery cache (populated from /sap/bc/adt/discovery

--- a/adt/repository_test.go
+++ b/adt/repository_test.go
@@ -169,6 +169,103 @@ func TestGetObjectInfoClass(t *testing.T) {
 	}
 }
 
+func TestGetObjectInfoVIT(t *testing.T) {
+	tests := []struct {
+		name      string
+		uri       string
+		wantType  string
+		objectXML string
+	}{
+		{
+			name:     "UIAC (UI annotation component)",
+			uri:      "/sap/bc/adt/vit/wb/object_type/uiac/object_name/%2fHFQ%2fTC_EXT",
+			wantType: "UIAC",
+			objectXML: `<?xml version="1.0" encoding="utf-8"?>
+<wb:objectProperties adtcore:name="/HFQ/TC_EXT" adtcore:type="UIAC"
+  adtcore:description="HFQ UI Annotation Component"
+  xmlns:wb="http://www.sap.com/adt/vit/wb"
+  xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:packageRef adtcore:name="/HFQ/MAIN"/>
+</wb:objectProperties>`,
+		},
+		{
+			name:     "UIAD (UI annotation definition)",
+			uri:      "/sap/bc/adt/vit/wb/object_type/uiad/object_name/%2fHFQ%2f95A365FBC361529D",
+			wantType: "UIAD",
+			objectXML: `<?xml version="1.0" encoding="utf-8"?>
+<wb:objectProperties adtcore:name="/HFQ/95A365FBC361529D" adtcore:type="UIAD"
+  adtcore:description="HFQ UI Annotation Definition"
+  xmlns:wb="http://www.sap.com/adt/vit/wb"
+  xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:packageRef adtcore:name="/HFQ/MAIN"/>
+</wb:objectProperties>`,
+		},
+		{
+			name:     "ADVC (advclrp URI subtype)",
+			uri:      "/sap/bc/adt/vit/wb/object_type/advclrp/object_name/%2fHFQ%2fIWGBLTCDZFMCAZLC5IN3LHTJZY",
+			wantType: "ADVC",
+			objectXML: `<?xml version="1.0" encoding="utf-8"?>
+<wb:objectProperties adtcore:name="/HFQ/IWGBLTCDZFMCAZLC5IN3LHTJZY" adtcore:type="ADVC"
+  adtcore:description="HFQ ADVC Object"
+  xmlns:wb="http://www.sap.com/adt/vit/wb"
+  xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:packageRef adtcore:name="/HFQ/MAIN"/>
+</wb:objectProperties>`,
+		},
+		{
+			name:     "WDCC (web Dynpro component configuration)",
+			uri:      "/sap/bc/adt/vit/wb/object_type/wdcc/object_name/%2fHFQ%2fBB7F8A229259B8B8C03A1EEC4C307",
+			wantType: "WDCC",
+			objectXML: `<?xml version="1.0" encoding="utf-8"?>
+<wb:objectProperties adtcore:name="/HFQ/BB7F8A229259B8B8C03A1EEC4C307" adtcore:type="WDCC"
+  adtcore:description="HFQ Web Dynpro Component Configuration"
+  xmlns:wb="http://www.sap.com/adt/vit/wb"
+  xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:packageRef adtcore:name="/HFQ/MAIN"/>
+</wb:objectProperties>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objectXML := tt.objectXML
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == csrfEndpoint {
+					w.Header().Set("X-CSRF-Token", "token")
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				accept := r.Header.Get("Accept")
+				if !strings.Contains(accept, "application/vnd.sap.adt.basic.object.properties+xml") {
+					w.WriteHeader(http.StatusNotAcceptable)
+					return
+				}
+				w.Header().Set("Content-Type", "application/vnd.sap.adt.basic.object.properties+xml")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(objectXML))
+			}))
+			defer srv.Close()
+
+			cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+			client := adt.NewClient(cfg)
+
+			info, err := client.GetObjectInfo(context.Background(), tt.uri)
+			if err != nil {
+				t.Fatalf("GetObjectInfo(%s) unexpected error: %v", tt.uri, err)
+			}
+			if info.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", info.Type, tt.wantType)
+			}
+			if info.Name == "" {
+				t.Error("Name is empty")
+			}
+			if info.PackageName == "" {
+				t.Error("PackageName is empty")
+			}
+		})
+	}
+}
+
 func TestGetObjectInfoInterface(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/sap/bc/adt/oo/interfaces/ZIF_EXAMPLE" {

--- a/adt/repository_test.go
+++ b/adt/repository_test.go
@@ -213,6 +213,18 @@ func TestGetObjectInfoVIT(t *testing.T) {
 </wb:objectProperties>`,
 		},
 		{
+			name:     "LRCC (lrcclrp URI subtype)",
+			uri:      "/sap/bc/adt/vit/wb/object_type/lrcclrp/object_name/%2fHFQ%2fW6SSBNYY2TNVIZKIDDTANNQPGY",
+			wantType: "LRCC",
+			objectXML: `<?xml version="1.0" encoding="utf-8"?>
+<wb:objectProperties adtcore:name="/HFQ/W6SSBNYY2TNVIZKIDDTANNQPGY" adtcore:type="LRCC"
+  adtcore:description="HFQ LRCC Object"
+  xmlns:wb="http://www.sap.com/adt/vit/wb"
+  xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:packageRef adtcore:name="/HFQ/MAIN"/>
+</wb:objectProperties>`,
+		},
+		{
 			name:     "WDCC (web Dynpro component configuration)",
 			uri:      "/sap/bc/adt/vit/wb/object_type/wdcc/object_name/%2fHFQ%2fBB7F8A229259B8B8C03A1EEC4C307",
 			wantType: "WDCC",

--- a/adt/vit_integration_test.go
+++ b/adt/vit_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package adt_test
+
+import (
+	"context"
+	"testing"
+)
+
+// TestGetObjectInfo_VIT_Integration exercises GetObjectInfo against real VIT
+// object URIs (/sap/bc/adt/vit/wb/object_type/...) to verify that adtler
+// sends Accept: application/vnd.sap.adt.basic.object.properties+xml and
+// successfully parses the response. Before the fix for adtler#72 these calls
+// returned HTTP 406. VIT objects only exist on S/4, so ECC systems will skip
+// individual cases when the object URI returns 404.
+func TestGetObjectInfo_VIT_Integration(t *testing.T) {
+	tests := []struct {
+		name    string
+		tadir   string // TADIR object type
+		uri     string
+		s4Only  bool
+	}{
+		{
+			name:   "UIAC",
+			tadir:  "UIAC",
+			uri:    "/sap/bc/adt/vit/wb/object_type/uiac/object_name/%2fHFQ%2fTC_EXT",
+			s4Only: true,
+		},
+		{
+			name:   "UIAD",
+			tadir:  "UIAD",
+			uri:    "/sap/bc/adt/vit/wb/object_type/uiad/object_name/%2fHFQ%2f95A365FBC361529D",
+			s4Only: true,
+		},
+		{
+			name:   "ADVC (advclrp)",
+			tadir:  "ADVC",
+			uri:    "/sap/bc/adt/vit/wb/object_type/advclrp/object_name/%2fHFQ%2fIWGBLTCDZFMCAZLC5IN3LHTJZY",
+			s4Only: true,
+		},
+		{
+			name:   "LRCC (lrcclrp)",
+			tadir:  "LRCC",
+			uri:    "/sap/bc/adt/vit/wb/object_type/lrcclrp/object_name/%2fHFQ%2fW6SSBNYY2TNVIZKIDDTANNQPGY",
+			s4Only: true,
+		},
+		{
+			name:   "WDCC",
+			tadir:  "WDCC",
+			uri:    "/sap/bc/adt/vit/wb/object_type/wdcc/object_name/%2fHFQ%2fBB7F8A229259B8B8C03A1EEC4C307",
+			s4Only: true,
+		},
+	}
+
+	for _, sys := range eachSystem(t) {
+		sys := sys
+		t.Run(sys.Name, func(t *testing.T) {
+			ctx := context.Background()
+			for _, tt := range tests {
+				tt := tt
+				t.Run(tt.name, func(t *testing.T) {
+					info, err := sys.Client.GetObjectInfo(ctx, tt.uri)
+					if err != nil {
+						// 404 is expected on ECC (VIT objects are S/4-only).
+						t.Logf("GetObjectInfo(%s) skipped: %v", tt.tadir, err)
+						t.Skip("object not found — likely ECC system or object does not exist")
+					}
+					if info.Name == "" {
+						t.Error("Name is empty")
+					}
+					if info.Type == "" {
+						t.Error("Type is empty")
+					}
+					t.Logf("name=%s type=%s description=%q package=%s", info.Name, info.Type, info.Description, info.PackageName)
+				})
+			}
+		})
+	}
+}

--- a/adt/vit_integration_test.go
+++ b/adt/vit_integration_test.go
@@ -15,40 +15,34 @@ import (
 // individual cases when the object URI returns 404.
 func TestGetObjectInfo_VIT_Integration(t *testing.T) {
 	tests := []struct {
-		name    string
-		tadir   string // TADIR object type
-		uri     string
-		s4Only  bool
+		name  string
+		tadir string // TADIR object type
+		uri   string
 	}{
 		{
-			name:   "UIAC",
-			tadir:  "UIAC",
-			uri:    "/sap/bc/adt/vit/wb/object_type/uiac/object_name/%2fHFQ%2fTC_EXT",
-			s4Only: true,
+			name:  "UIAC",
+			tadir: "UIAC",
+			uri:   "/sap/bc/adt/vit/wb/object_type/uiac/object_name/%2fHFQ%2fTC_EXT",
 		},
 		{
-			name:   "UIAD",
-			tadir:  "UIAD",
-			uri:    "/sap/bc/adt/vit/wb/object_type/uiad/object_name/%2fHFQ%2f95A365FBC361529D",
-			s4Only: true,
+			name:  "UIAD",
+			tadir: "UIAD",
+			uri:   "/sap/bc/adt/vit/wb/object_type/uiad/object_name/%2fHFQ%2f95A365FBC361529D",
 		},
 		{
-			name:   "ADVC (advclrp)",
-			tadir:  "ADVC",
-			uri:    "/sap/bc/adt/vit/wb/object_type/advclrp/object_name/%2fHFQ%2fIWGBLTCDZFMCAZLC5IN3LHTJZY",
-			s4Only: true,
+			name:  "ADVC (advclrp)",
+			tadir: "ADVC",
+			uri:   "/sap/bc/adt/vit/wb/object_type/advclrp/object_name/%2fHFQ%2fIWGBLTCDZFMCAZLC5IN3LHTJZY",
 		},
 		{
-			name:   "LRCC (lrcclrp)",
-			tadir:  "LRCC",
-			uri:    "/sap/bc/adt/vit/wb/object_type/lrcclrp/object_name/%2fHFQ%2fW6SSBNYY2TNVIZKIDDTANNQPGY",
-			s4Only: true,
+			name:  "LRCC (lrcclrp)",
+			tadir: "LRCC",
+			uri:   "/sap/bc/adt/vit/wb/object_type/lrcclrp/object_name/%2fHFQ%2fW6SSBNYY2TNVIZKIDDTANNQPGY",
 		},
 		{
-			name:   "WDCC",
-			tadir:  "WDCC",
-			uri:    "/sap/bc/adt/vit/wb/object_type/wdcc/object_name/%2fHFQ%2fBB7F8A229259B8B8C03A1EEC4C307",
-			s4Only: true,
+			name:  "WDCC",
+			tadir: "WDCC",
+			uri:   "/sap/bc/adt/vit/wb/object_type/wdcc/object_name/%2fHFQ%2fBB7F8A229259B8B8C03A1EEC4C307",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- `GetObjectInfo` for VIT object URIs (`/sap/bc/adt/vit/wb/object_type/...`) was returning HTTP 406 because adtler sent `application/xml` instead of the required `application/vnd.sap.adt.basic.object.properties+xml`
- Add `/sap/bc/adt/vit/wb/object_type` to `objectTypeAcceptHeaders` with a new `vitObjectPropertiesContentType` constant
- Add table-driven unit tests for all five affected TADIR types (UIAC, UIAD, ADVC, LRCC, WDCC) verifying the Accept header and XML parsing
- Add multi-system integration test in `vit_integration_test.go` using `eachSystem(t)` (gracefully skips on ECC where VIT objects don't exist)

Fixes #72.

## Test plan

- [x] `go test ./...` passes
- [x] `go build -tags integration ./adt/...` and `go vet -tags integration ./adt/...` pass
- [x] Integration test `TestGetObjectInfo_VIT_Integration` must pass against S4U

🤖 Generated with [Claude Code](https://claude.com/claude-code)