### PR TITLE
refactor: remove auto-merge step from workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,7 @@ This agent does NOT push code — it runs tests and comments only.
 If the integration test passes and CI is green:
 
 - Remove the `needs:integration-test` label
-- Enable auto-merge squash: `gh pr merge <N> --auto --squash`
-- The PR squash-merges when all required checks complete
+- The PR is ready to merge — the author decides when and how to merge
 
 ### Labels (workflow-relevant)
 


### PR DESCRIPTION
## Summary

- Step 5 of the merge workflow previously included `gh pr merge <N> --auto --squash` as an automatic action
- Replaced with: "The PR is ready to merge — the author decides when and how to merge"
- The merge decision belongs to the PR author, not to an automated agent step

🤖 Generated with [Claude Code](https://claude.com/claude-code)