### PR TITLE
feat: expose ObjectURI(objectType, name) helper

### DIFF
--- a/adt/object.go
+++ b/adt/object.go
@@ -49,6 +49,10 @@ func supportedObjectTypes() []string {
 // name, e.g. ObjectURI("PROG", "ZFOO") == "/sap/bc/adt/programs/programs/zfoo".
 // The name is lower-cased to match the ADT REST URI convention. It returns an
 // error for object types not known to objectTypeMap.
+//
+// The name is appended verbatim (after lower-casing) and is not URL-encoded, so
+// callers passing namespaced names (e.g. "/NS/NAME") are responsible for any
+// required escaping; an empty name yields a trailing slash.
 func ObjectURI(objectType, name string) (string, error) {
 	info, ok := objectTypeMap[strings.ToUpper(objectType)]
 	if !ok {

--- a/adt/object.go
+++ b/adt/object.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/Hochfrequenz/adtler/adt/adtxml"
@@ -33,14 +34,33 @@ var objectTypeMap = map[string]struct {
 	"MSAG":      {"/sap/bc/adt/messageclass", "MSAG/N"},
 }
 
+// supportedObjectTypes returns the object-type keys known to objectTypeMap,
+// sorted for deterministic error messages.
+func supportedObjectTypes() []string {
+	supported := make([]string, 0, len(objectTypeMap))
+	for k := range objectTypeMap {
+		supported = append(supported, k)
+	}
+	sort.Strings(supported)
+	return supported
+}
+
+// ObjectURI returns the ADT resource URI for an object of the given type and
+// name, e.g. ObjectURI("PROG", "ZFOO") == "/sap/bc/adt/programs/programs/zfoo".
+// The name is lower-cased to match the ADT REST URI convention. It returns an
+// error for object types not known to objectTypeMap.
+func ObjectURI(objectType, name string) (string, error) {
+	info, ok := objectTypeMap[strings.ToUpper(objectType)]
+	if !ok {
+		return "", fmt.Errorf("unsupported object type %q, supported: %s", objectType, strings.Join(supportedObjectTypes(), ", "))
+	}
+	return info.endpoint + "/" + strings.ToLower(name), nil
+}
+
 func (c *httpClient) CreateObject(ctx context.Context, objectType, name, packageName, description, transport string) error {
 	info, ok := objectTypeMap[strings.ToUpper(objectType)]
 	if !ok {
-		supported := make([]string, 0, len(objectTypeMap))
-		for k := range objectTypeMap {
-			supported = append(supported, k)
-		}
-		return fmt.Errorf("unsupported object type %q, supported: %s", objectType, strings.Join(supported, ", "))
+		return fmt.Errorf("unsupported object type %q, supported: %s", objectType, strings.Join(supportedObjectTypes(), ", "))
 	}
 
 	var body []byte

--- a/adt/object_uri_test.go
+++ b/adt/object_uri_test.go
@@ -1,0 +1,61 @@
+package adt_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+)
+
+func TestObjectURI(t *testing.T) {
+	cases := []struct {
+		name       string
+		objectType string
+		objName    string
+		want       string
+	}{
+		{"program", "PROG", "ZFOO", "/sap/bc/adt/programs/programs/zfoo"},
+		{"class", "CLAS", "ZCL_BAR", "/sap/bc/adt/oo/classes/zcl_bar"},
+		{"interface", "INTF", "ZIF_BAZ", "/sap/bc/adt/oo/interfaces/zif_baz"},
+		{"function group", "FUGR", "ZFG", "/sap/bc/adt/functions/groups/zfg"},
+		{"data element", "DTEL", "ZDE", "/sap/bc/adt/ddic/dataelements/zde"},
+		{"domain", "DOMA", "ZDO", "/sap/bc/adt/ddic/domains/zdo"},
+		{"table", "TABL", "ZTAB", "/sap/bc/adt/ddic/tables/ztab"},
+		{"ddl source", "DDLS", "ZCDS", "/sap/bc/adt/ddic/ddl/sources/zcds"},
+		{"message class", "MSAG", "ZMSG", "/sap/bc/adt/messageclass/zmsg"},
+		// Object type is matched case-insensitively, name is lower-cased.
+		{"lowercase type", "prog", "ZFOO", "/sap/bc/adt/programs/programs/zfoo"},
+		{"already lower name", "PROG", "zfoo", "/sap/bc/adt/programs/programs/zfoo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := adt.ObjectURI(tc.objectType, tc.objName)
+			if err != nil {
+				t.Fatalf("ObjectURI(%q, %q): unexpected error: %v", tc.objectType, tc.objName, err)
+			}
+			if got != tc.want {
+				t.Errorf("ObjectURI(%q, %q) = %q, want %q", tc.objectType, tc.objName, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestObjectURI_UnsupportedType(t *testing.T) {
+	got, err := adt.ObjectURI("BOGUS", "ZFOO")
+	if err == nil {
+		t.Fatalf("ObjectURI(\"BOGUS\", ...) = %q, want error", got)
+	}
+	if got != "" {
+		t.Errorf("ObjectURI returned %q alongside an error, want empty string", got)
+	}
+	// The error should name the offending type and list supported types so
+	// callers (and humans) can recover.
+	if !strings.Contains(err.Error(), `"BOGUS"`) {
+		t.Errorf("error %q should mention the unsupported type", err.Error())
+	}
+	for _, want := range []string{"PROG", "CLAS", "MSAG"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should list supported type %q", err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds a public `ObjectURI(objectType, name string) (string, error)` helper that builds the ADT resource URI for an object from its type + name, backed by the existing private `objectTypeMap`.

```go
adt.ObjectURI("PROG", "ZFOO") // -> "/sap/bc/adt/programs/programs/zfoo", nil
```

- Name is lower-cased to match the ADT REST URI convention.
- Object type is matched case-insensitively.
- Unknown types return an error listing the supported types.

Also extracts the supported-types listing into `supportedObjectTypes()` (sorted, deterministic) so the error message is shared between `ObjectURI` and `CreateObject` rather than duplicating the map-iteration block — pre-empts a `dupl` finding.

## Why

mcp-server-abap reimplements subsets of this object-type → endpoint mapping in two places (`tools/rollback.go`'s `sourceTypeToEndpoint`, and a hardcoded literal in `tools/verify.go`). Exposing `ObjectURI` lets those duplicates be deleted on the next bump.

Closes #75. Consumer: Hochfrequenz/aibap.mcp#410

## Tests

- `adt/object_uri_test.go` — table-driven coverage of all 9 mapped types, case-insensitive type, already-lower name, and the unsupported-type error (empty return + type named + supported list present).
- `go test ./...` green; `go vet ./...` clean; `go build -tags integration ./adt/...` compiles.

No integration test: `ObjectURI` is a pure string function with no HTTP/SAP interaction, so the `eachSystem(t)` pattern does not apply. The URIs it produces are already exercised against live SAP via `CreateObject`/`GetSource` etc., which read from the same `objectTypeMap`.

## Lint note

`golangci-lint` is not installed in my environment so I could not run it locally; the `supportedObjectTypes()` extraction was done specifically to avoid the `dupl` duplication the two identical list-builders would otherwise trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)