### PR TITLE
feat: SearchPackages helper + exported ObjectTypePackage constant

### DIFF
--- a/adt/client.go
+++ b/adt/client.go
@@ -69,6 +69,7 @@ type NavigationClient interface {
 // SearchClient provides object discovery.
 type SearchClient interface {
 	SearchObjects(ctx context.Context, query, objectType string, maxResults int) ([]ObjectInfo, error)
+	SearchPackages(ctx context.Context, query string, maxResults int) ([]ObjectInfo, error)
 	WhereUsed(ctx context.Context, objectURI string) ([]ObjectInfo, error)
 	BrowsePackage(ctx context.Context, packageName string) ([]ObjectInfo, error)
 	GetObjectInfo(ctx context.Context, objectURI string) (*ObjectInfo, error)

--- a/adt/client_test.go
+++ b/adt/client_test.go
@@ -22,6 +22,10 @@ const checkrunsPath = "/sap/bc/adt/checkruns"
 // CreateObject's post-create session cleanup. Hoisted for goconst.
 const logoffPath = "/sap/public/bc/icf/logoff"
 
+// searchEndpoint is the repository information-system quick-search endpoint
+// used by SearchObjects/SearchPackages tests. Hoisted for goconst.
+const searchEndpoint = "/sap/bc/adt/repository/informationsystem/search"
+
 // progType is the ADT object type for ABAP programs, used in assertions
 // across multiple test files. Hoisted for goconst.
 const progType = "PROG/P"

--- a/adt/custexport/export_test.go
+++ b/adt/custexport/export_test.go
@@ -49,6 +49,9 @@ func (m *mockClient) GetInactiveObjects(context.Context) ([]adt.ObjectInfo, erro
 func (m *mockClient) SearchObjects(context.Context, string, string, int) ([]adt.ObjectInfo, error) {
 	panic("not implemented")
 }
+func (m *mockClient) SearchPackages(context.Context, string, int) ([]adt.ObjectInfo, error) {
+	panic("not implemented")
+}
 func (m *mockClient) WhereUsed(context.Context, string) ([]adt.ObjectInfo, error) {
 	panic("not implemented")
 }

--- a/adt/object.go
+++ b/adt/object.go
@@ -19,6 +19,10 @@ const (
 	objTypeDDLS = "DDLS"
 )
 
+// ObjectTypePackage is the ADT object type code for a package (DEVCLASS),
+// used as the objectType in searches and the type in package creation/browse.
+const ObjectTypePackage = "DEVC/K"
+
 var objectTypeMap = map[string]struct {
 	endpoint string
 	adtType  string
@@ -227,7 +231,7 @@ func (c *httpClient) CreatePackage(ctx context.Context, name, description, respo
 		NSPak:       "http://www.sap.com/adt/packages",
 		NSCore:      nsADTCore,
 		Name:        strings.ToUpper(name),
-		Type:        "DEVC/K",
+		Type:        ObjectTypePackage,
 		Description: description,
 		Responsible: strings.ToUpper(responsible),
 		Attributes:  adtxml.PakAttributes{PackageType: "development"},

--- a/adt/registry.go
+++ b/adt/registry.go
@@ -119,6 +119,9 @@ func (r *ClientRegistry) GetTableFields(ctx context.Context, tableName string) (
 func (r *ClientRegistry) SearchObjects(ctx context.Context, query, objectType string, maxResults int) ([]ObjectInfo, error) {
 	return r.activeClient().SearchObjects(ctx, query, objectType, maxResults)
 }
+func (r *ClientRegistry) SearchPackages(ctx context.Context, query string, maxResults int) ([]ObjectInfo, error) {
+	return r.activeClient().SearchPackages(ctx, query, maxResults)
+}
 func (r *ClientRegistry) WhereUsed(ctx context.Context, objectURI string) ([]ObjectInfo, error) {
 	return r.activeClient().WhereUsed(ctx, objectURI)
 }

--- a/adt/registry_test.go
+++ b/adt/registry_test.go
@@ -153,7 +153,7 @@ func allEndpointsHandler() http.Handler {
 		case path == activatePath:
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklist"><chkl:properties checkExecuted="false" activationExecuted="false" generationExecuted="true"/></chkl:messages>`))
-		case path == "/sap/bc/adt/repository/informationsystem/search":
+		case path == searchEndpoint:
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(emptyObjectRefs))
 		case path == "/sap/bc/adt/repository/nodestructure":

--- a/adt/repository.go
+++ b/adt/repository.go
@@ -14,7 +14,7 @@ import (
 
 func (c *httpClient) BrowsePackage(ctx context.Context, packageName string) ([]ObjectInfo, error) {
 	params := url.Values{}
-	params.Set("parent_type", "DEVC/K")
+	params.Set("parent_type", ObjectTypePackage)
 	params.Set("parent_name", packageName)
 	path := "/sap/bc/adt/repository/nodestructure?" + params.Encode()
 

--- a/adt/search.go
+++ b/adt/search.go
@@ -52,6 +52,13 @@ func (c *httpClient) SearchObjects(ctx context.Context, query, objectType string
 	return parseObjectReferences(data)
 }
 
+// SearchPackages searches for packages (DEVC) whose name matches query, up to
+// maxResults. It is SearchObjects constrained to the package object type, so
+// callers need not know the ADT type code.
+func (c *httpClient) SearchPackages(ctx context.Context, query string, maxResults int) ([]ObjectInfo, error) {
+	return c.SearchObjects(ctx, query, ObjectTypePackage, maxResults)
+}
+
 func (c *httpClient) WhereUsed(ctx context.Context, objectURI string) ([]ObjectInfo, error) {
 	params := url.Values{}
 	params.Set("uri", objectURI)

--- a/adt/search_test.go
+++ b/adt/search_test.go
@@ -53,6 +53,53 @@ func TestSearchObjects(t *testing.T) {
 	}
 }
 
+func TestSearchPackages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/sap/bc/adt/repository/informationsystem/search" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		q := r.URL.Query()
+		if q.Get("operation") != "quickSearch" {
+			t.Errorf("operation: got %q", q.Get("operation"))
+		}
+		if q.Get("query") != "ZPKG*" {
+			t.Errorf("query: got %q", q.Get("query"))
+		}
+		// SearchPackages must constrain the search to the package object type.
+		if q.Get("objectType") != adt.ObjectTypePackage {
+			t.Errorf("objectType: got %q, want %q", q.Get("objectType"), adt.ObjectTypePackage)
+		}
+		if q.Get("maxResults") != "5" {
+			t.Errorf("maxResults: got %q", q.Get("maxResults"))
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<?xml version="1.0"?>
+<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
+  <adtcore:objectReference adtcore:uri="/sap/bc/adt/packages/ZPKG_TEST" adtcore:type="DEVC/K" adtcore:name="ZPKG_TEST" adtcore:description="Test Package"/>
+</adtcore:objectReferences>`))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	results, err := client.SearchPackages(context.Background(), "ZPKG*", 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Name != "ZPKG_TEST" {
+		t.Errorf("name: got %q", results[0].Name)
+	}
+	if results[0].Type != adt.ObjectTypePackage {
+		t.Errorf("type: got %q, want %q", results[0].Type, adt.ObjectTypePackage)
+	}
+}
+
 func TestWhereUsed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == csrfEndpoint {

--- a/adt/search_test.go
+++ b/adt/search_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSearchObjects(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/sap/bc/adt/repository/informationsystem/search" {
+		if r.URL.Path != searchEndpoint {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -55,7 +55,7 @@ func TestSearchObjects(t *testing.T) {
 
 func TestSearchPackages(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/sap/bc/adt/repository/informationsystem/search" {
+		if r.URL.Path != searchEndpoint {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}


### PR DESCRIPTION
## What

- Adds `SearchPackages(ctx, query string, maxResults int) ([]ObjectInfo, error)` — `SearchObjects` constrained to the package object type. Added to the `SearchClient` interface, `httpClient`, and `ClientRegistry`.
- Exports `const ObjectTypePackage = "DEVC/K"` and uses it to de-duplicate the literal already hardcoded in `CreatePackage` (object.go) and `BrowsePackage` (repository.go).

## Why

mcp-server-abap's `tools/export.go` hardcodes `SearchObjects(ctx, pattern, "DEVC/K", max)`. The `"DEVC/K"` TADIR type code is ADT domain knowledge and should live in adtler. After this, the consumer calls `SearchPackages` (or the constant) and the type code never leaves adtler.

Closes #77. Consumer: Hochfrequenz/aibap.mcp#412

## Interface change (note for reviewers)

`SearchPackages` is added to the exported `SearchClient` interface (embedded in `adt.Client`). This is **additive** — any external type implementing the interface must add the method. The only in-repo full-`adt.Client` implementer outside the real clients is the custexport test mock, updated in this PR. The primary consumer (mcp-server-abap) adapts its mocks in the #412 bump PR.

## Tests

- `adt/search_test.go::TestSearchPackages` — asserts the request carries `objectType=DEVC/K`, `operation=quickSearch`, query + maxResults, and parses the package result.
- Existing `TestCreatePackage`/`TestBrowsePackage` still pass (constant substitution is behavior-preserving).
- `go test ./...` green; `go vet ./...` clean; `go build -tags integration ./adt/...` compiles.

No integration test: `SearchPackages` is a thin constraint over `SearchObjects` (already integration-tested) and adds no new HTTP behavior; `ObjectTypePackage` is a constant.

## Lint note

`golangci-lint` not installed locally; CI runs it. No new duplication introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)