### PR TITLE
feat: export TextElementLockURI(objectURI) helper

### DIFF
--- a/adt/textelements.go
+++ b/adt/textelements.go
@@ -136,6 +136,15 @@ func (c *httpClient) writeTextElementSource(ctx context.Context, path, contentTy
 	return checkResponse(resp)
 }
 
+// TextElementLockURI returns the ADT textelements resource URI that the text
+// symbols and selection texts of the given object are bound to. SAP attaches
+// the enqueue lock for text elements to this resource rather than to the object
+// itself, so callers that lock before SetTextElements must acquire the lock on
+// this URI. The objectURI must be a program, class, or function group URI.
+func TextElementLockURI(objectURI string) (string, error) {
+	return resolveTextElementPath(objectURI)
+}
+
 func resolveTextElementPath(objectURI string) (string, error) {
 	upper := strings.ToUpper(objectURI)
 	for prefix, tePath := range textElementEndpoints {
@@ -145,7 +154,7 @@ func resolveTextElementPath(objectURI string) (string, error) {
 			return tePath + name, nil
 		}
 	}
-	return "", fmt.Errorf("GetTextElements: unsupported object type for URI %q (only programs, classes, function groups)", objectURI)
+	return "", fmt.Errorf("unsupported object type for text elements: URI %q (only programs, classes, function groups)", objectURI)
 }
 
 func (c *httpClient) readTextElementSource(ctx context.Context, path, accept string) (string, error) {

--- a/adt/textelements_test.go
+++ b/adt/textelements_test.go
@@ -73,6 +73,22 @@ func TestResolveTextElementPath(t *testing.T) {
 	}
 }
 
+func TestTextElementLockURI(t *testing.T) {
+	// The public wrapper must return the same textelements resource URI that
+	// SetTextElements writes to, so callers lock the correct enqueue resource.
+	got, err := TextElementLockURI("/sap/bc/adt/programs/programs/ZTEST")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "/sap/bc/adt/textelements/programs/ZTEST"; got != want {
+		t.Errorf("TextElementLockURI = %q, want %q", got, want)
+	}
+
+	if _, err := TextElementLockURI("/sap/bc/adt/ddic/tables/ZTABLE"); err == nil {
+		t.Error("expected error for unsupported object type")
+	}
+}
+
 func TestFormatTextSymbols(t *testing.T) {
 	symbols := []TextSymbol{
 		{Key: "001", Text: "Hello World", MaxLength: 50},

--- a/adt/textelements_test.go
+++ b/adt/textelements_test.go
@@ -84,6 +84,17 @@ func TestTextElementLockURI(t *testing.T) {
 		t.Errorf("TextElementLockURI = %q, want %q", got, want)
 	}
 
+	// The prefix is matched case-insensitively (the original-case name suffix
+	// is preserved). This is the behavior that differs from a naive
+	// case-sensitive rewrite, so pin it down.
+	got, err = TextElementLockURI("/SAP/BC/ADT/programs/programs/ZFoo")
+	if err != nil {
+		t.Fatalf("unexpected error on mixed-case prefix: %v", err)
+	}
+	if want := "/sap/bc/adt/textelements/programs/ZFoo"; got != want {
+		t.Errorf("TextElementLockURI(mixed-case) = %q, want %q", got, want)
+	}
+
 	if _, err := TextElementLockURI("/sap/bc/adt/ddic/tables/ZTABLE"); err == nil {
 		t.Error("expected error for unsupported object type")
 	}


### PR DESCRIPTION
## What

- Adds `TextElementLockURI(objectURI string) (string, error)` — a thin public wrapper over the private `resolveTextElementPath`, returning the `/sap/bc/adt/textelements/...` resource URI an object's text elements are bound to.
- Neutralizes `resolveTextElementPath`'s `"GetTextElements: ..."` error prefix (shared by GetTextElements, SetTextElements, and the new helper).

## Why

`SetTextElements` resolves this path internally but doesn't expose it, so mcp-server-abap reimplements the program/class/function-group → textelements rewrite (`textElementsResourceURI`) just to know which enqueue resource to lock — SAP binds the text-element lock to that resource, not the object. The two copies have already diverged (adtler is case-insensitive; the consumer copy is case-sensitive). Exposing this lets the duplicate be deleted.

Closes #79. Consumer: Hochfrequenz/aibap.mcp#411

## Tests

- `adt/textelements_test.go::TestTextElementLockURI` — asserts the wrapper returns the same textelements URI SetTextElements writes to (program case) and errors on an unsupported object type. The existing `TestResolveTextElementPath` (covering classes/function groups) still passes.
- `go test ./...` green; `go vet` clean; `golangci-lint --enable dupl,goconst,gocyclo` → 0 issues; `go build -tags integration ./adt/...` compiles.

No integration test: the helper is a pure URI derivation with no HTTP; the resulting URIs are exercised against live SAP via the existing SetTextElements/GetTextElements integration tests.

## API note

Additive export only — no interface change (it's a package-level function, not a method), so no implementers/mocks are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)