### PR TITLE
feat: ErrorKind + ClassifyError; export remaining ExceptionType constants

### DIFF
--- a/adt/errorkind.go
+++ b/adt/errorkind.go
@@ -1,0 +1,154 @@
+package adt
+
+import "errors"
+
+// ErrorKind is a stable, language- and (where possible) system-independent
+// classification of an ADT error. It is derived from ADTError.Type when the
+// error carries a modern <exc:exception> envelope, and from the HTTP status
+// code otherwise. It lets callers branch on the *meaning* of a failure without
+// substring-matching localised messages or re-encoding SAP's cross-system
+// status-code quirks (e.g. "already exists" is 400 on S/4 but 405 on R/3).
+//
+// ErrorKind classifies the protocol-level error only. Conditions SAP does not
+// surface with a distinct Type or status — a name collision reported as a
+// generic creation failure, or a "transport required" hidden inside a 400 —
+// are reported as their broad kind (ErrorCreationFailed, ErrorBadRequest);
+// callers wanting finer detail inspect the message themselves.
+type ErrorKind int
+
+const (
+	// ErrorUnknown is returned for non-ADTError errors and for ADT errors that
+	// match no known Type or status code.
+	ErrorUnknown           ErrorKind = iota
+	ErrorAlreadyExists               // an object with that name already exists
+	ErrorLocked                      // the object is locked by another user/transport
+	ErrorLockConflict                // save/lock conflict — a different enqueue is held
+	ErrorInvalidLockHandle           // the supplied lock handle is invalid or expired
+	ErrorEtagMismatch                // an If-Match / ETag precondition failed
+	ErrorNotAcceptable               // content negotiation failed (Accept)
+	ErrorUnsupportedMedia            // the request Content-Type is not accepted
+	ErrorUnprocessable               // the request is semantically invalid
+	ErrorMethodNotAllowed            // the method is not allowed for the resource
+	ErrorCreationFailed              // object creation failed (often a name collision)
+	ErrorNotFound                    // the object or resource was not found
+	ErrorForbidden                   // authorization error
+	ErrorBadRequest                  // the request was malformed
+	ErrorServerError                 // SAP server error (HTTP 500)
+)
+
+// String returns a stable, lowercase identifier for the kind (handy for logs
+// and for keying hint tables). It is not localised.
+func (k ErrorKind) String() string {
+	switch k {
+	case ErrorAlreadyExists:
+		return "already_exists"
+	case ErrorLocked:
+		return "locked"
+	case ErrorLockConflict:
+		return "lock_conflict"
+	case ErrorInvalidLockHandle:
+		return "invalid_lock_handle"
+	case ErrorEtagMismatch:
+		return "etag_mismatch"
+	case ErrorNotAcceptable:
+		return "not_acceptable"
+	case ErrorUnsupportedMedia:
+		return "unsupported_media"
+	case ErrorUnprocessable:
+		return "unprocessable"
+	case ErrorMethodNotAllowed:
+		return "method_not_allowed"
+	case ErrorCreationFailed:
+		return "creation_failed"
+	case ErrorNotFound:
+		return "not_found"
+	case ErrorForbidden:
+		return "forbidden"
+	case ErrorBadRequest:
+		return "bad_request"
+	case ErrorServerError:
+		return "server_error"
+	default:
+		return "unknown"
+	}
+}
+
+// ClassifyError maps an error to an ErrorKind. Non-ADTError errors (and nil)
+// classify as ErrorUnknown. For an *ADTError, the SAP-stable Type is consulted
+// first (it is language- and status-independent); when the Type is empty or
+// unrecognised, the HTTP status code is used as a fallback.
+//
+// Note: a bare 423 with no Type classifies as ErrorLocked here. That is
+// deliberately distinct from the internal invalid-lock-handle retry heuristic,
+// which treats a typeless 423 as an invalid lock handle for SetSource's
+// delivery-mechanism fallback.
+func ClassifyError(err error) ErrorKind {
+	var adtErr *ADTError
+	if !errors.As(err, &adtErr) {
+		return ErrorUnknown
+	}
+	if k := classifyByExceptionType(adtErr.Type); k != ErrorUnknown {
+		return k
+	}
+	return classifyByStatusCode(adtErr.StatusCode)
+}
+
+// classifyByExceptionType maps a SAP <exc:exception> Type id to a kind, or
+// ErrorUnknown if the Type is empty or not recognised.
+func classifyByExceptionType(excType string) ErrorKind {
+	switch excType {
+	case ExceptionTypeResourceAlreadyExists:
+		return ErrorAlreadyExists
+	case ExceptionTypeResourceLocked:
+		return ErrorLocked
+	case ExceptionTypeResourceLockConflict:
+		return ErrorLockConflict
+	case ExceptionTypeResourceInvalidLockHandle:
+		return ErrorInvalidLockHandle
+	case ExceptionTypeResourceInvalidEtag, ExceptionTypePreconditionFailed:
+		return ErrorEtagMismatch
+	case ExceptionTypeResourceNotAcceptable:
+		return ErrorNotAcceptable
+	case ExceptionTypeUnsupportedMediaType:
+		return ErrorUnsupportedMedia
+	case ExceptionTypeUnprocessableEntity, ExceptionTypeResourceWrongData:
+		return ErrorUnprocessable
+	case ExceptionTypeNotAllowed:
+		return ErrorMethodNotAllowed
+	case ExceptionTypeResourceCreationFailure:
+		return ErrorCreationFailed
+	default:
+		return ErrorUnknown
+	}
+}
+
+// classifyByStatusCode maps an HTTP status code to a kind, or ErrorUnknown for
+// codes with no specific classification.
+func classifyByStatusCode(status int) ErrorKind {
+	switch status {
+	case 423:
+		return ErrorLocked
+	case 412:
+		return ErrorEtagMismatch
+	case 409:
+		return ErrorLockConflict
+	case 406:
+		return ErrorNotAcceptable
+	case 415:
+		return ErrorUnsupportedMedia
+	case 422:
+		return ErrorUnprocessable
+	case 405:
+		return ErrorMethodNotAllowed
+	case 404:
+		return ErrorNotFound
+	case 403:
+		return ErrorForbidden
+	case 400:
+		return ErrorBadRequest
+	case 500:
+		return ErrorServerError
+	default:
+		return ErrorUnknown
+	}
+}

--- a/adt/errorkind_test.go
+++ b/adt/errorkind_test.go
@@ -109,14 +109,26 @@ func TestClassifyError_WrappedADTError(t *testing.T) {
 
 func TestErrorKind_String(t *testing.T) {
 	cases := map[adt.ErrorKind]string{
-		adt.ErrorUnknown:        "unknown",
-		adt.ErrorAlreadyExists:  "already_exists",
-		adt.ErrorLocked:         "locked",
-		adt.ErrorLockConflict:   "lock_conflict",
-		adt.ErrorEtagMismatch:   "etag_mismatch",
-		adt.ErrorCreationFailed: "creation_failed",
-		adt.ErrorNotFound:       "not_found",
-		adt.ErrorServerError:    "server_error",
+		adt.ErrorUnknown:           "unknown",
+		adt.ErrorAlreadyExists:     "already_exists",
+		adt.ErrorLocked:            "locked",
+		adt.ErrorLockConflict:      "lock_conflict",
+		adt.ErrorInvalidLockHandle: "invalid_lock_handle",
+		adt.ErrorEtagMismatch:      "etag_mismatch",
+		adt.ErrorNotAcceptable:     "not_acceptable",
+		adt.ErrorUnsupportedMedia:  "unsupported_media",
+		adt.ErrorUnprocessable:     "unprocessable",
+		adt.ErrorMethodNotAllowed:  "method_not_allowed",
+		adt.ErrorCreationFailed:    "creation_failed",
+		adt.ErrorNotFound:          "not_found",
+		adt.ErrorForbidden:         "forbidden",
+		adt.ErrorBadRequest:        "bad_request",
+		adt.ErrorServerError:       "server_error",
+	}
+	// Guard against an unhandled kind silently returning "unknown": a bogus
+	// value must map to "unknown", but every named kind above must not.
+	if got := adt.ErrorKind(999).String(); got != "unknown" {
+		t.Errorf("out-of-range kind = %q, want %q", got, "unknown")
 	}
 	for kind, want := range cases {
 		if got := kind.String(); got != want {

--- a/adt/errorkind_test.go
+++ b/adt/errorkind_test.go
@@ -1,0 +1,126 @@
+package adt_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+)
+
+func TestClassifyError_ByExceptionType(t *testing.T) {
+	cases := []struct {
+		excType string
+		want    adt.ErrorKind
+	}{
+		{adt.ExceptionTypeResourceAlreadyExists, adt.ErrorAlreadyExists},
+		{adt.ExceptionTypeResourceLocked, adt.ErrorLocked},
+		{adt.ExceptionTypeResourceLockConflict, adt.ErrorLockConflict},
+		{adt.ExceptionTypeResourceInvalidLockHandle, adt.ErrorInvalidLockHandle},
+		{adt.ExceptionTypeResourceInvalidEtag, adt.ErrorEtagMismatch},
+		{adt.ExceptionTypePreconditionFailed, adt.ErrorEtagMismatch},
+		{adt.ExceptionTypeResourceNotAcceptable, adt.ErrorNotAcceptable},
+		{adt.ExceptionTypeUnsupportedMediaType, adt.ErrorUnsupportedMedia},
+		{adt.ExceptionTypeUnprocessableEntity, adt.ErrorUnprocessable},
+		{adt.ExceptionTypeResourceWrongData, adt.ErrorUnprocessable},
+		{adt.ExceptionTypeNotAllowed, adt.ErrorMethodNotAllowed},
+		{adt.ExceptionTypeResourceCreationFailure, adt.ErrorCreationFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.excType, func(t *testing.T) {
+			err := &adt.ADTError{Type: tc.excType, StatusCode: 200, Message: "x"}
+			if got := adt.ClassifyError(err); got != tc.want {
+				t.Errorf("ClassifyError(Type=%s) = %v, want %v", tc.excType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyError_ByStatusCode(t *testing.T) {
+	cases := []struct {
+		status int
+		want   adt.ErrorKind
+	}{
+		{423, adt.ErrorLocked},
+		{412, adt.ErrorEtagMismatch},
+		{409, adt.ErrorLockConflict},
+		{406, adt.ErrorNotAcceptable},
+		{415, adt.ErrorUnsupportedMedia},
+		{422, adt.ErrorUnprocessable},
+		{405, adt.ErrorMethodNotAllowed},
+		{404, adt.ErrorNotFound},
+		{403, adt.ErrorForbidden},
+		{400, adt.ErrorBadRequest},
+		{500, adt.ErrorServerError},
+		{418, adt.ErrorUnknown}, // unmapped status
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("status_%d", tc.status), func(t *testing.T) {
+			// Empty Type forces the status-code fallback.
+			err := &adt.ADTError{StatusCode: tc.status, Message: "x"}
+			if got := adt.ClassifyError(err); got != tc.want {
+				t.Errorf("ClassifyError(status=%d) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyError_TypeTakesPrecedenceOverStatus(t *testing.T) {
+	// On R/3, "already exists" arrives as HTTP 405 but with the AlreadyExists
+	// Type. Type must win over the status-code fallback (which would say
+	// MethodNotAllowed).
+	err := &adt.ADTError{StatusCode: 405, Type: adt.ExceptionTypeResourceAlreadyExists, Message: "exists"}
+	if got := adt.ClassifyError(err); got != adt.ErrorAlreadyExists {
+		t.Errorf("got %v, want ErrorAlreadyExists", got)
+	}
+}
+
+func TestClassifyError_UnrecognisedTypeFallsBackToStatus(t *testing.T) {
+	err := &adt.ADTError{StatusCode: 404, Type: "ExceptionSomethingBrandNew", Message: "x"}
+	if got := adt.ClassifyError(err); got != adt.ErrorNotFound {
+		t.Errorf("got %v, want ErrorNotFound (status fallback)", got)
+	}
+}
+
+func TestClassifyError_BareLockStatusIsLockedNotInvalidHandle(t *testing.T) {
+	// A typeless 423 classifies as ErrorLocked (the general meaning), distinct
+	// from the internal invalid-lock-handle retry heuristic.
+	err := &adt.ADTError{StatusCode: 423, Message: "locked"}
+	if got := adt.ClassifyError(err); got != adt.ErrorLocked {
+		t.Errorf("got %v, want ErrorLocked", got)
+	}
+}
+
+func TestClassifyError_NonADTError(t *testing.T) {
+	if got := adt.ClassifyError(errors.New("plain error")); got != adt.ErrorUnknown {
+		t.Errorf("plain error: got %v, want ErrorUnknown", got)
+	}
+	if got := adt.ClassifyError(nil); got != adt.ErrorUnknown {
+		t.Errorf("nil: got %v, want ErrorUnknown", got)
+	}
+}
+
+func TestClassifyError_WrappedADTError(t *testing.T) {
+	wrapped := fmt.Errorf("set source: %w", &adt.ADTError{StatusCode: 412, Message: "etag"})
+	if got := adt.ClassifyError(wrapped); got != adt.ErrorEtagMismatch {
+		t.Errorf("wrapped: got %v, want ErrorEtagMismatch", got)
+	}
+}
+
+func TestErrorKind_String(t *testing.T) {
+	cases := map[adt.ErrorKind]string{
+		adt.ErrorUnknown:        "unknown",
+		adt.ErrorAlreadyExists:  "already_exists",
+		adt.ErrorLocked:         "locked",
+		adt.ErrorLockConflict:   "lock_conflict",
+		adt.ErrorEtagMismatch:   "etag_mismatch",
+		adt.ErrorCreationFailed: "creation_failed",
+		adt.ErrorNotFound:       "not_found",
+		adt.ErrorServerError:    "server_error",
+	}
+	for kind, want := range cases {
+		if got := kind.String(); got != want {
+			t.Errorf("ErrorKind(%d).String() = %q, want %q", kind, got, want)
+		}
+	}
+}

--- a/adt/types.go
+++ b/adt/types.go
@@ -144,6 +144,18 @@ const (
 	ExceptionTypeResourceLocked            = "ExceptionResourceLocked"
 	ExceptionTypePreconditionFailed        = "ExceptionPreconditionFailed"
 	ExceptionTypeResourceWrongData         = "ExceptionResourceWrongData"
+	ExceptionTypeResourceAlreadyExists     = "ExceptionResourceAlreadyExists" // 400 on S/4, 405 on R/3
+	ExceptionTypeResourceLockConflict      = "ExceptionResourceLockConflict"  // 409, S/4 only
+	ExceptionTypeResourceInvalidEtag       = "ExceptionResourceInvalidEtag"   // 412
+	ExceptionTypeResourceNotAcceptable     = "ExceptionResourceNotAcceptable" // 406
+	ExceptionTypeUnsupportedMediaType      = "ExceptionUnsupportedMediaType"  // 415
+	ExceptionTypeUnprocessableEntity       = "ExceptionUnprocessableEntity"   // 422
+	ExceptionTypeNotAllowed                = "ExceptionNotAllowed"            // 405, S/4 only
+	// ExceptionTypeResourceCreationFailure is raised (HTTP 500) when an object
+	// create cannot complete. The PROGRAM-create endpoint reports a name
+	// collision this way rather than as ExceptionResourceAlreadyExists —
+	// verified live on both S/4 and R/3 (mcp-server-abap #406 / #407).
+	ExceptionTypeResourceCreationFailure = "ExceptionResourceCreationFailure"
 )
 
 // ADTError is returned when SAP ADT responds with an error status.


### PR DESCRIPTION
## What

1. **Export 8 more `ExceptionType*` constants** in `adt/types.go` (AlreadyExists, LockConflict, InvalidEtag, NotAcceptable, UnsupportedMediaType, UnprocessableEntity, NotAllowed, CreationFailure), each annotated with its cross-system HTTP status.
2. **Add `ErrorKind` + `ClassifyError`** (`adt/errorkind.go`): `ClassifyError(err) ErrorKind` maps an `*ADTError` to a stable kind — by SAP `Type` first (language/status-independent), then by HTTP status as a fallback. `ErrorKind.String()` gives stable lowercase ids for logging/keying.

## Why

mcp-server-abap's `tools/errors.go` redeclares these 8 constants and encodes the cross-system `(Type, status) → meaning` tiering locally. That is SAP protocol knowledge and belongs in adtler; the MCP layer should keep only the hint *wording* (which names MCP tools), keyed by `ErrorKind`.

Closes #81. Consumer: Hochfrequenz/aibap.mcp#413 (the consumer migration is coordinated with aibap.mcp#363 — this PR is the adtler-side API only).

## Design decisions (please scrutinise)

- **Type precedence:** `ClassifyError` consults `Type` before status, so R/3's typed 405-AlreadyExists → `ErrorAlreadyExists`, not `ErrorMethodNotAllowed`. Unrecognised/empty Type falls through to the status switch.
- **Bare 423 → `ErrorLocked`**, deliberately distinct from the internal `isInvalidLockHandle` heuristic (typeless 423 = invalid lock handle, for SetSource's delivery-mechanism retry). `isInvalidLockHandle` is intentionally left untouched — wiring it to ClassifyError would regress that retry.
- **`ExceptionTypeResourceWrongData`** (pre-existing constant) → `ErrorUnprocessable`.
- Split into `classifyByExceptionType` + `classifyByStatusCode` to keep each function's cyclomatic complexity well under the gocyclo threshold.

## Tests

`adt/errorkind_test.go`: every Type→kind, every status→kind (incl. an unmapped status → Unknown), Type-precedence-over-status, unrecognised-Type-falls-back-to-status, bare-423→Locked, non-ADTError/nil→Unknown, wrapped (`%w`) ADTError, and `String()` values.

`go test ./...` green; `go vet` clean; `golangci-lint --enable dupl,goconst,gocyclo` → 0 issues; `go build -tags integration ./adt/...` compiles.

No integration test: pure classification over the already-parsed `ADTError`; no new HTTP/SAP interaction. No interface changed (package-level func + constants), so no mocks affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)