### PR TITLE
feat: ReleaseTransportVerified — detect ECC silent-fail release

### DIFF
--- a/adt/client.go
+++ b/adt/client.go
@@ -115,6 +115,7 @@ type TransportClient interface {
 	DeleteTransport(ctx context.Context, transportNumber string) error
 	ReleaseTransport(ctx context.Context, transportNumber string) error
 	ReleaseTransportWithTasks(ctx context.Context, transportNumber string) error
+	ReleaseTransportVerified(ctx context.Context, transportNumber string, includeTasks bool) (*ReleaseResult, error)
 	GetTransportRequests(ctx context.Context, user, status string) ([]TransportRequest, error)
 	AddToTransport(ctx context.Context, objectURI, transport string) error
 	RemoveFromTransport(ctx context.Context, taskNumber, parentTransport, pgmID, objectType, objectName, wbType, position string) error

--- a/adt/custexport/export_test.go
+++ b/adt/custexport/export_test.go
@@ -133,6 +133,9 @@ func (m *mockClient) DeleteTransport(context.Context, string) error {
 func (m *mockClient) ReleaseTransport(context.Context, string) error {
 	panic("not implemented")
 }
+func (m *mockClient) ReleaseTransportVerified(context.Context, string, bool) (*adt.ReleaseResult, error) {
+	panic("not implemented")
+}
 func (m *mockClient) ReleaseTransportWithTasks(context.Context, string) error {
 	panic("not implemented")
 }

--- a/adt/registry.go
+++ b/adt/registry.go
@@ -179,6 +179,9 @@ func (r *ClientRegistry) RemoveFromTransport(ctx context.Context, taskNumber, pa
 func (r *ClientRegistry) ReleaseTransportWithTasks(ctx context.Context, transportNumber string) error {
 	return r.activeClient().ReleaseTransportWithTasks(ctx, transportNumber)
 }
+func (r *ClientRegistry) ReleaseTransportVerified(ctx context.Context, transportNumber string, includeTasks bool) (*ReleaseResult, error) {
+	return r.activeClient().ReleaseTransportVerified(ctx, transportNumber, includeTasks)
+}
 func (r *ClientRegistry) GetTransportInfo(ctx context.Context, transportNumber string) (*TransportRequest, error) {
 	return r.activeClient().GetTransportInfo(ctx, transportNumber)
 }

--- a/adt/release_verified_test.go
+++ b/adt/release_verified_test.go
@@ -1,0 +1,102 @@
+package adt_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+	sapmcpconfig "github.com/Hochfrequenz/sap-mcp-config"
+)
+
+// releaseVerifiedServer mocks a synchronous release followed by a status read.
+// postReleaseStatus is the tm:status attribute returned by the status GET; pass
+// "" to make the status read fail (no <request> element).
+func releaseVerifiedServer(t *testing.T, transport, postReleaseStatus string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == csrfEndpoint:
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "newreleasejobs"):
+			// Synchronous release: report "released".
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" xmlns:chkrun="http://www.sap.com/adt/checkrun">
+  <tm:releasereports><tm:checkReport chkrun:status="released"/></tm:releasereports>
+</tm:root>`))
+		case r.Method == http.MethodGet && r.URL.Path == "/sap/bc/adt/cts/transportrequests/"+transport:
+			if postReleaseStatus == "" {
+				// No request element → GetTransportInfo errors.
+				_, _ = w.Write([]byte(`<?xml version="1.0"?><tm:root xmlns:tm="http://www.sap.com/cts/adt/tm"/>`))
+				return
+			}
+			_, _ = w.Write([]byte(`<?xml version="1.0"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm">
+  <tm:request tm:number="` + transport + `" tm:desc="d" tm:status="` + postReleaseStatus + `"/>
+</tm:root>`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestReleaseTransportVerified(t *testing.T) {
+	cases := []struct {
+		name              string
+		postReleaseStatus string
+		wantReleased      bool
+	}{
+		{"released (status L)", adt.TransportStatusReleased, true},
+		{"silent fail (status D)", adt.TransportStatusModifiable, false},
+		{"status read fails -> optimistic released", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const transport = "DEVK900123"
+			srv := releaseVerifiedServer(t, transport, tc.postReleaseStatus)
+			defer srv.Close()
+
+			cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+			client := adt.NewClient(cfg)
+
+			res, err := client.ReleaseTransportVerified(context.Background(), transport, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.Transport != transport {
+				t.Errorf("Transport = %q, want %q", res.Transport, transport)
+			}
+			if res.Released != tc.wantReleased {
+				t.Errorf("Released = %v, want %v", res.Released, tc.wantReleased)
+			}
+		})
+	}
+}
+
+func TestReleaseTransportVerified_ReleaseErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Both release endpoints fail → ReleaseTransport returns an error.
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	res, err := client.ReleaseTransportVerified(context.Background(), "DEVK900123", false)
+	if err == nil {
+		t.Fatalf("expected error, got result %+v", res)
+	}
+	if res != nil {
+		t.Errorf("expected nil result on error, got %+v", res)
+	}
+}

--- a/adt/transport.go
+++ b/adt/transport.go
@@ -179,6 +179,47 @@ func (c *httpClient) ReleaseTransportWithTasks(ctx context.Context, transportNum
 	return c.releaseTransport(ctx, transportNumber, true)
 }
 
+// ReleaseResult reports the outcome of a verified transport release.
+type ReleaseResult struct {
+	Transport string `json:"transport"`
+	// Released is true when the request is confirmed no longer modifiable
+	// after the release. It is false — with a nil error — when the release
+	// endpoint reported success but the request stayed modifiable, the
+	// "silent failure" some systems (notably ECC) exhibit.
+	Released bool `json:"released"`
+}
+
+// ReleaseTransportVerified releases a transport request (optionally including
+// its tasks) and then confirms the outcome by re-reading the request status.
+//
+// The plain ReleaseTransport reports success whenever the release endpoint
+// returns 2xx and its release report carries no error — but some systems
+// (notably ECC) return 200 while leaving the request modifiable. This method
+// detects that by checking the post-release status: a request still in the
+// modifiable ("D") state is reported as Released=false (with a nil error) so
+// callers can fall back to another release mechanism. A genuine release error
+// is returned unchanged.
+//
+// If the post-release status read fails, the release is assumed to have
+// succeeded (Released=true) — the optimistic behavior callers had before
+// verification existed.
+func (c *httpClient) ReleaseTransportVerified(ctx context.Context, transportNumber string, includeTasks bool) (*ReleaseResult, error) {
+	var err error
+	if includeTasks {
+		err = c.ReleaseTransportWithTasks(ctx, transportNumber)
+	} else {
+		err = c.ReleaseTransport(ctx, transportNumber)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if info, infoErr := c.GetTransportInfo(ctx, transportNumber); infoErr == nil && info != nil && info.Status == TransportStatusModifiable {
+		return &ReleaseResult{Transport: transportNumber, Released: false}, nil
+	}
+	return &ReleaseResult{Transport: transportNumber, Released: true}, nil
+}
+
 func (c *httpClient) releaseTransport(ctx context.Context, transportNumber string, releaseTasks bool) error {
 	err := c.releaseTransportDirect(ctx, transportNumber)
 	if err == nil {

--- a/adt/types.go
+++ b/adt/types.go
@@ -71,6 +71,12 @@ type TransportRequest struct {
 	Status      string // "D" = modifiable, "L" = released
 }
 
+// Transport request status codes (TransportRequest.Status).
+const (
+	TransportStatusModifiable = "D" // request is open / editable
+	TransportStatusReleased   = "L" // request has been released
+)
+
 // TransportCheckResult is returned by CheckTransport.
 type TransportCheckResult struct {
 	PgmID      string             // R3TR, LIMU, etc.


### PR DESCRIPTION
## What

- Adds `ReleaseTransportVerified(ctx, transportNumber string, includeTasks bool) (*ReleaseResult, error)`: releases (optionally with tasks), then re-reads the request status to confirm. A request still modifiable (`"D"`) after a 2xx release → `Released=false` with a **nil error** (the ECC "silent failure"); a genuine release error is returned unchanged; an unreadable post-release status is treated optimistically as `Released=true` (matching prior caller behavior).
- Adds `ReleaseResult{Transport, Released}`.
- Exports `TransportStatusModifiable = "D"` / `TransportStatusReleased = "L"`.

## Why

mcp-server-abap's `release_transport` handler does this exact post-release `GetTransportInfo` + `Status == "D"` check inline — ADT response semantics that belong here beside `checkReleaseResponse`. The BlackMagic fallback *routing* stays MCP-side.

Closes #83. Consumer: Hochfrequenz/aibap.mcp#414.

## API shape (note for reviewers)

Chose the **additive** path: a new method + result type rather than changing `ReleaseTransport`'s `error`-only signature (which would break all callers). `ReleaseTransportVerified` is added to the exported `TransportClient` interface — the only in-repo full-`adt.Client` implementer outside the real clients is the custexport test mock, updated here. The consumer adapts its mock in the #414 bump.

`includeTasks bool` is a single param rather than a second `…WithTasksVerified` method — it composes over the existing `ReleaseTransport`/`ReleaseTransportWithTasks` split internally.

## Tests

`adt/release_verified_test.go`: synchronous release then status read returning `L` (Released=true), `D` (silent-fail Released=false), and an unreadable status (optimistic Released=true); plus release-error-propagates (nil result + error).

`go test ./...` green; `go vet` clean; `golangci-lint --enable dupl,goconst,gocyclo` → 0 issues; `go build -tags integration ./adt/...` compiles.

No integration test added here: the verified flow composes `ReleaseTransport` + `GetTransportInfo`, both already integration-tested; the silent-fail path is ECC-specific and is exercised by the #414 consumer reproducer on bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)