### PR TITLE
feat: RollbackTransport — restore a transport's objects to their pre-transport version

### DIFF
--- a/adt/client.go
+++ b/adt/client.go
@@ -116,6 +116,7 @@ type TransportClient interface {
 	ReleaseTransport(ctx context.Context, transportNumber string) error
 	ReleaseTransportWithTasks(ctx context.Context, transportNumber string) error
 	ReleaseTransportVerified(ctx context.Context, transportNumber string, includeTasks bool) (*ReleaseResult, error)
+	RollbackTransport(ctx context.Context, transportNumber string) (*RollbackResult, error)
 	GetTransportRequests(ctx context.Context, user, status string) ([]TransportRequest, error)
 	AddToTransport(ctx context.Context, objectURI, transport string) error
 	RemoveFromTransport(ctx context.Context, taskNumber, parentTransport, pgmID, objectType, objectName, wbType, position string) error

--- a/adt/custexport/export_test.go
+++ b/adt/custexport/export_test.go
@@ -136,6 +136,9 @@ func (m *mockClient) ReleaseTransport(context.Context, string) error {
 func (m *mockClient) ReleaseTransportVerified(context.Context, string, bool) (*adt.ReleaseResult, error) {
 	panic("not implemented")
 }
+func (m *mockClient) RollbackTransport(context.Context, string) (*adt.RollbackResult, error) {
+	panic("not implemented")
+}
 func (m *mockClient) ReleaseTransportWithTasks(context.Context, string) error {
 	panic("not implemented")
 }

--- a/adt/registry.go
+++ b/adt/registry.go
@@ -182,6 +182,9 @@ func (r *ClientRegistry) ReleaseTransportWithTasks(ctx context.Context, transpor
 func (r *ClientRegistry) ReleaseTransportVerified(ctx context.Context, transportNumber string, includeTasks bool) (*ReleaseResult, error) {
 	return r.activeClient().ReleaseTransportVerified(ctx, transportNumber, includeTasks)
 }
+func (r *ClientRegistry) RollbackTransport(ctx context.Context, transportNumber string) (*RollbackResult, error) {
+	return r.activeClient().RollbackTransport(ctx, transportNumber)
+}
 func (r *ClientRegistry) GetTransportInfo(ctx context.Context, transportNumber string) (*TransportRequest, error) {
 	return r.activeClient().GetTransportInfo(ctx, transportNumber)
 }

--- a/adt/rollback.go
+++ b/adt/rollback.go
@@ -1,0 +1,149 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// RollbackEntry is one object processed by RollbackTransport.
+type RollbackEntry struct {
+	Type   string `json:"type"`
+	Name   string `json:"name"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// RollbackResult reports the outcome of RollbackTransport, partitioning the
+// transport's objects into those restored, skipped, and failed.
+type RollbackResult struct {
+	Restored []RollbackEntry `json:"restored"`
+	Skipped  []RollbackEntry `json:"skipped"`
+	Failed   []RollbackEntry `json:"failed"`
+}
+
+// rollbackSourceTypes is the set of object types RollbackTransport restores
+// source for. DDIC types (TABL, DTEL, ...) are intentionally excluded and
+// skipped — they have no source to roll back the same way.
+var rollbackSourceTypes = map[string]bool{
+	"PROG": true,
+	"CLAS": true,
+	"INTF": true,
+	"FUGR": true,
+}
+
+// RollbackTransport restores every source object in a transport to its version
+// immediately before the transport. For each R3TR PROG/CLAS/INTF/FUGR object it
+// reads the version history, finds the pre-transport version, and writes that
+// source back (lock → set → activate). Non-source objects (TABL, DTEL, …) and
+// non-R3TR entries are skipped. Objects created by the transport (no prior
+// version) are reported as failed.
+//
+// This is destructive: it overwrites current source with historical versions.
+func (c *httpClient) RollbackTransport(ctx context.Context, transport string) (*RollbackResult, error) {
+	objects, err := c.GetTransportObjects(ctx, transport)
+	if err != nil {
+		return nil, fmt.Errorf("reading transport objects: %w", err)
+	}
+
+	result := &RollbackResult{}
+	for _, obj := range objects {
+		if obj.PgmID != "R3TR" {
+			result.Skipped = append(result.Skipped, RollbackEntry{
+				Type: obj.Type, Name: obj.Name, Reason: "not R3TR",
+			})
+			continue
+		}
+		if !rollbackSourceTypes[obj.Type] {
+			result.Skipped = append(result.Skipped, RollbackEntry{
+				Type: obj.Type, Name: obj.Name, Reason: "non-source object type",
+			})
+			continue
+		}
+		objectURI, err := ObjectURI(obj.Type, obj.Name)
+		if err != nil {
+			result.Skipped = append(result.Skipped, RollbackEntry{
+				Type: obj.Type, Name: obj.Name, Reason: err.Error(),
+			})
+			continue
+		}
+		if err := c.rollbackObject(ctx, objectURI, transport); err != nil {
+			result.Failed = append(result.Failed, RollbackEntry{
+				Type: obj.Type, Name: obj.Name, Reason: err.Error(),
+			})
+		} else {
+			result.Restored = append(result.Restored, RollbackEntry{
+				Type: obj.Type, Name: obj.Name,
+			})
+		}
+	}
+	return result, nil
+}
+
+// findPreTransportVersion returns the ContentURI of the version immediately
+// preceding the given transport in the version history. The history is ordered
+// newest-first, so the entry after the transport's own version is the object's
+// state before the transport changed it. It errors if the transport is absent
+// from the history, or if no earlier version exists (the object was created by
+// this transport).
+func findPreTransportVersion(versions []VersionInfo, transport string) (string, error) {
+	seenTransport := false
+	for _, v := range versions {
+		if v.Transport == transport {
+			seenTransport = true
+			continue
+		}
+		if seenTransport {
+			return v.ContentURI, nil
+		}
+	}
+	if !seenTransport {
+		return "", fmt.Errorf("transport %s not found in version history", transport)
+	}
+	return "", fmt.Errorf("no version before transport %s (object may have been created by this transport)", transport)
+}
+
+// rollbackObject restores a single object's source to its pre-transport version.
+func (c *httpClient) rollbackObject(ctx context.Context, objectURI, transport string) error {
+	versions, err := c.GetVersionHistory(ctx, objectURI)
+	if err != nil {
+		return fmt.Errorf("get version history: %w", err)
+	}
+
+	restoreURI, err := findPreTransportVersion(versions, transport)
+	if err != nil {
+		return err
+	}
+
+	oldSource, err := c.GetVersionSource(ctx, restoreURI)
+	if err != nil {
+		return fmt.Errorf("get version source: %w", err)
+	}
+
+	lockHandle, err := c.LockObject(ctx, objectURI)
+	if err != nil {
+		return fmt.Errorf("lock: %w", err)
+	}
+	defer func() { _ = c.UnlockObject(ctx, objectURI, lockHandle) }()
+
+	current, err := c.GetSource(ctx, objectURI)
+	if err != nil {
+		return fmt.Errorf("get current source: %w", err)
+	}
+
+	if _, err := c.SetSource(ctx, objectURI, oldSource, lockHandle, "", current.ETag); err != nil {
+		return fmt.Errorf("set source: %w", err)
+	}
+
+	actResult, err := c.ActivateObjects(ctx, []string{objectURI})
+	if err != nil {
+		return fmt.Errorf("activate: %w", err)
+	}
+	if !actResult.Success {
+		msgs := make([]string, len(actResult.Messages))
+		for i, m := range actResult.Messages {
+			msgs[i] = m.Text
+		}
+		return fmt.Errorf("activation failed: %s", strings.Join(msgs, "; "))
+	}
+	return nil
+}

--- a/adt/rollback.go
+++ b/adt/rollback.go
@@ -87,19 +87,25 @@ func (c *httpClient) RollbackTransport(ctx context.Context, transport string) (*
 // this transport).
 func findPreTransportVersion(versions []VersionInfo, transport string) (string, error) {
 	seenTransport := false
+	restoreURI := ""
 	for _, v := range versions {
 		if v.Transport == transport {
 			seenTransport = true
 			continue
 		}
 		if seenTransport {
-			return v.ContentURI, nil
+			restoreURI = v.ContentURI
+			break
 		}
 	}
 	if !seenTransport {
 		return "", fmt.Errorf("transport %s not found in version history", transport)
 	}
-	return "", fmt.Errorf("no version before transport %s (object may have been created by this transport)", transport)
+	// An empty ContentURI is treated the same as no earlier version at all.
+	if restoreURI == "" {
+		return "", fmt.Errorf("no version before transport %s (object may have been created by this transport)", transport)
+	}
+	return restoreURI, nil
 }
 
 // rollbackObject restores a single object's source to its pre-transport version.

--- a/adt/rollback_test.go
+++ b/adt/rollback_test.go
@@ -1,0 +1,106 @@
+package adt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sapmcpconfig "github.com/Hochfrequenz/sap-mcp-config"
+)
+
+func TestFindPreTransportVersion(t *testing.T) {
+	t.Run("returns version after the transport entry", func(t *testing.T) {
+		// History is newest-first: the transport's own version, then the prior.
+		versions := []VersionInfo{
+			{VersionNumber: "2", Transport: "DEVK900100"},
+			{VersionNumber: "1", Transport: "DEVK900001", ContentURI: "uri-pre"},
+		}
+		got, err := findPreTransportVersion(versions, "DEVK900100")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "uri-pre" {
+			t.Errorf("got %q, want %q", got, "uri-pre")
+		}
+	})
+
+	t.Run("transport spanning multiple versions takes the first earlier one", func(t *testing.T) {
+		versions := []VersionInfo{
+			{VersionNumber: "3", Transport: "DEVK900100"},
+			{VersionNumber: "2", Transport: "DEVK900100"},
+			{VersionNumber: "1", Transport: "DEVK900001", ContentURI: "uri-pre"},
+		}
+		got, err := findPreTransportVersion(versions, "DEVK900100")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "uri-pre" {
+			t.Errorf("got %q, want %q", got, "uri-pre")
+		}
+	})
+
+	t.Run("transport not in history", func(t *testing.T) {
+		versions := []VersionInfo{
+			{VersionNumber: "2", Transport: "DEVK900001"},
+			{VersionNumber: "1", Transport: "DEVK900000"},
+		}
+		if _, err := findPreTransportVersion(versions, "DEVK900100"); err == nil {
+			t.Error("expected error when transport is absent from history")
+		}
+	})
+
+	t.Run("object created by the transport (no earlier version)", func(t *testing.T) {
+		versions := []VersionInfo{
+			{VersionNumber: "1", Transport: "DEVK900100"},
+		}
+		if _, err := findPreTransportVersion(versions, "DEVK900100"); err == nil {
+			t.Error("expected error when there is no version before the transport")
+		}
+	})
+}
+
+// TestRollbackTransport_SkipsNonRestorable confirms the filtering: non-R3TR
+// entries and non-source object types are skipped without any restore work
+// (so only the transport-objects read is needed).
+func TestRollbackTransport_SkipsNonRestorable(t *testing.T) {
+	const transport = "DEVK900100"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/sap/bc/adt/cts/transportrequests/"+transport {
+			_, _ = w.Write([]byte(`<?xml version="1.0"?>
+<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm">
+  <tm:request tm:number="` + transport + `">
+    <tm:abap_object tm:pgmid="LIMU" tm:type="REPS" tm:name="ZFOO_PART"/>
+    <tm:abap_object tm:pgmid="R3TR" tm:type="TABL" tm:name="ZTABLE"/>
+  </tm:request>
+</tm:root>`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := NewClient(cfg)
+
+	result, err := client.RollbackTransport(context.Background(), transport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Restored) != 0 || len(result.Failed) != 0 {
+		t.Errorf("expected nothing restored/failed, got restored=%v failed=%v", result.Restored, result.Failed)
+	}
+	if len(result.Skipped) != 2 {
+		t.Fatalf("expected 2 skipped, got %d: %+v", len(result.Skipped), result.Skipped)
+	}
+	reasons := map[string]string{}
+	for _, e := range result.Skipped {
+		reasons[e.Name] = e.Reason
+	}
+	if reasons["ZFOO_PART"] != "not R3TR" {
+		t.Errorf("LIMU object reason = %q, want %q", reasons["ZFOO_PART"], "not R3TR")
+	}
+	if reasons["ZTABLE"] != "non-source object type" {
+		t.Errorf("TABL object reason = %q, want %q", reasons["ZTABLE"], "non-source object type")
+	}
+}

--- a/adt/rollback_test.go
+++ b/adt/rollback_test.go
@@ -58,6 +58,16 @@ func TestFindPreTransportVersion(t *testing.T) {
 			t.Error("expected error when there is no version before the transport")
 		}
 	})
+
+	t.Run("earlier version with empty ContentURI is treated as no earlier version", func(t *testing.T) {
+		versions := []VersionInfo{
+			{VersionNumber: "2", Transport: "DEVK900100"},
+			{VersionNumber: "1", Transport: "DEVK900001", ContentURI: ""},
+		}
+		if _, err := findPreTransportVersion(versions, "DEVK900100"); err == nil {
+			t.Error("expected error when the earlier version has no ContentURI")
+		}
+	})
 }
 
 // TestRollbackTransport_SkipsNonRestorable confirms the filtering: non-R3TR


### PR DESCRIPTION
## What

Adds `RollbackTransport(ctx, transportNumber string) (*RollbackResult, error)` and the `RollbackResult`/`RollbackEntry` types (`adt/rollback.go`). For each **R3TR** PROG/CLAS/INTF/FUGR object in the transport it reads the version history, finds the version immediately before the transport, and restores that source (lock → get-etag → set → activate). Non-R3TR entries and non-source object types (TABL, DTEL, …) are **skipped**; objects created by the transport (no prior version) are reported as **failed**.

The version-walking heuristic is extracted as `findPreTransportVersion` (history is newest-first; the entry after the transport's own version is the pre-transport state).

Added to the `TransportClient` interface, `ClientRegistry`, and the custexport test mock.

## Why

mcp-server-abap's `rollback_transport` tool implements this whole multi-call workflow inline (`doRollback`/`rollbackObject`). The SAP-specific parts — the R3TR/source-type filter, the version heuristic, the edit/activate dance — are built from adtler primitives and belong here. The MCP layer keeps only the destructive-action elicitation and result shaping.

Closes #85. Consumer: Hochfrequenz/aibap.mcp#416.

## Tests

- `TestFindPreTransportVersion` (pure, the SAP-specific heuristic): version-after-transport, transport spanning multiple versions, transport-not-in-history, object-created-by-transport.
- `TestRollbackTransport_SkipsNonRestorable` (httptest): a transport with a LIMU entry (→ "not R3TR") and an R3TR TABL (→ "non-source object type") — both skipped, no restore work.

`go test ./...` green; `go vet` clean; `golangci-lint --enable dupl,goconst,gocyclo` → 0 issues; `go build -tags integration ./adt/...` compiles.

No full-restore httptest: the lock→set→activate dance composes already-integration-tested primitives (`GetVersionSource`, `LockObject`, `SetSource`, `ActivateObjects`); the end-to-end restore is exercised by the #416 consumer reproducer against a live system on bump.

## Interface note

`RollbackTransport` is added to the exported `TransportClient` interface — the consumer's `mockClient` (the only full-`adt.Client` double on that side) will need the method in the #416 bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)