### PR TITLE
feat: VerifySource — syntax-check standalone ABAP source via a throwaway $TMP program

### DIFF
--- a/adt/client.go
+++ b/adt/client.go
@@ -95,6 +95,7 @@ type DumpClient interface {
 type QualityClient interface {
 	SyntaxCheck(ctx context.Context, objectURI string) ([]SyntaxMessage, error)
 	BatchSyntaxCheck(ctx context.Context, objectURIs []string) []ObjectSyntaxResult
+	VerifySource(ctx context.Context, source string) (valid bool, messages []SyntaxMessage, err error)
 	RunUnitTests(ctx context.Context, objectURI string, timeoutSeconds int) (*TestResult, error)
 	RunATCCheck(ctx context.Context, objectURIs []string, checkVariant string) (*ATCResult, error)
 	GetATCCustomizing(ctx context.Context) (*ATCCustomizingResult, error)

--- a/adt/client_test.go
+++ b/adt/client_test.go
@@ -26,6 +26,9 @@ const logoffPath = "/sap/public/bc/icf/logoff"
 // used by SearchObjects/SearchPackages tests. Hoisted for goconst.
 const searchEndpoint = "/sap/bc/adt/repository/informationsystem/search"
 
+// programsEndpoint is the ADT programs collection endpoint. Hoisted for goconst.
+const programsEndpoint = "/sap/bc/adt/programs/programs"
+
 // progType is the ADT object type for ABAP programs, used in assertions
 // across multiple test files. Hoisted for goconst.
 const progType = "PROG/P"

--- a/adt/custexport/export_test.go
+++ b/adt/custexport/export_test.go
@@ -64,6 +64,9 @@ func (m *mockClient) GetObjectInfo(context.Context, string) (*adt.ObjectInfo, er
 func (m *mockClient) SyntaxCheck(context.Context, string) ([]adt.SyntaxMessage, error) {
 	panic("not implemented")
 }
+func (m *mockClient) VerifySource(context.Context, string) (bool, []adt.SyntaxMessage, error) {
+	panic("not implemented")
+}
 func (m *mockClient) BatchSyntaxCheck(context.Context, []string) []adt.ObjectSyntaxResult {
 	panic("not implemented")
 }

--- a/adt/registry.go
+++ b/adt/registry.go
@@ -134,6 +134,9 @@ func (r *ClientRegistry) GetObjectInfo(ctx context.Context, objectURI string) (*
 func (r *ClientRegistry) SyntaxCheck(ctx context.Context, objectURI string) ([]SyntaxMessage, error) {
 	return r.activeClient().SyntaxCheck(ctx, objectURI)
 }
+func (r *ClientRegistry) VerifySource(ctx context.Context, source string) (bool, []SyntaxMessage, error) {
+	return r.activeClient().VerifySource(ctx, source)
+}
 func (r *ClientRegistry) BatchSyntaxCheck(ctx context.Context, objectURIs []string) []ObjectSyntaxResult {
 	return r.activeClient().BatchSyntaxCheck(ctx, objectURIs)
 }

--- a/adt/verify.go
+++ b/adt/verify.go
@@ -1,0 +1,65 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+)
+
+// VerifySource syntax-checks standalone ABAP source without requiring an
+// existing object. It creates a temporary program in the local $TMP package,
+// writes the source, runs a syntax check against the inactive version, and
+// deletes the temporary program again. valid is true when the check produced
+// no error-severity ("E") messages.
+//
+// SAP's checkruns endpoint does not support checking inline source on ECC or
+// S/4 (it ignores the inline body / rejects the action), so this throwaway-$TMP
+// round-trip is the portable way to validate free-standing source. See
+// mcp-server-abap#126.
+func (c *httpClient) VerifySource(ctx context.Context, source string) (valid bool, messages []SyntaxMessage, err error) {
+	name := fmt.Sprintf("Z_ADTLER_VERIFY_%06d", rand.Intn(1000000)) //nolint:gosec // throwaway temp object name, not security-sensitive
+	objectURI, err := ObjectURI("PROG", name)
+	if err != nil {
+		return false, nil, fmt.Errorf("VerifySource: %w", err)
+	}
+
+	if err := c.CreateObject(ctx, "PROG", name, "$TMP", "adtler VerifySource temp", ""); err != nil {
+		return false, nil, fmt.Errorf("VerifySource: create temp object: %w", err)
+	}
+
+	// Ensure the temporary program is removed regardless of outcome.
+	defer func() {
+		if lh, lockErr := c.LockObject(ctx, objectURI); lockErr == nil {
+			_ = c.DeleteObject(ctx, objectURI, lh, "")
+		}
+	}()
+
+	lockHandle, err := c.LockObject(ctx, objectURI)
+	if err != nil {
+		return false, nil, fmt.Errorf("VerifySource: lock: %w", err)
+	}
+	src, err := c.GetSource(ctx, objectURI)
+	if err != nil {
+		_ = c.UnlockObject(ctx, objectURI, lockHandle)
+		return false, nil, fmt.Errorf("VerifySource: get source for etag: %w", err)
+	}
+	if _, err := c.SetSource(ctx, objectURI, source, lockHandle, "", src.ETag); err != nil {
+		_ = c.UnlockObject(ctx, objectURI, lockHandle)
+		return false, nil, fmt.Errorf("VerifySource: set source: %w", err)
+	}
+	_ = c.UnlockObject(ctx, objectURI, lockHandle)
+
+	messages, err = c.SyntaxCheck(ctx, objectURI)
+	if err != nil {
+		return false, nil, fmt.Errorf("VerifySource: syntax check: %w", err)
+	}
+
+	valid = true
+	for _, m := range messages {
+		if m.Type == "E" {
+			valid = false
+			break
+		}
+	}
+	return valid, messages, nil
+}

--- a/adt/verify_test.go
+++ b/adt/verify_test.go
@@ -1,0 +1,107 @@
+package adt_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+	sapmcpconfig "github.com/Hochfrequenz/sap-mcp-config"
+)
+
+var checkObjectURIRe = regexp.MustCompile(`adtcore:uri="([^"]+)"`)
+
+// verifySourceServer mocks the full VerifySource round-trip: CSRF, create temp
+// program, lock, get-source (for etag), set-source, unlock, syntax check, and
+// delete. The /checkruns handler echoes the requested object URI as the
+// report's triggeringUri (which SyntaxCheck correlates on) and, when withError
+// is set, includes one error-severity message.
+func verifySourceServer(withError bool) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == csrfEndpoint:
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == logoffPath:
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == checkrunsPath && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			uri := ""
+			if m := checkObjectURIRe.FindStringSubmatch(string(body)); m != nil {
+				uri = m[1]
+			}
+			msg := ""
+			if withError {
+				msg = `<chkrun:checkMessage chkrun:uri="` + uri + `/source/main#start=2,5" chkrun:type="E" chkrun:shortText="Field &quot;FOO&quot; is unknown."/>`
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+<chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun">
+  <chkrun:checkReport chkrun:reporter="abapCheckRun" chkrun:triggeringUri="` + uri + `" chkrun:status="processed" chkrun:statusText="Syntax check performed">
+    <chkrun:checkMessageList>` + msg + `</chkrun:checkMessageList>
+  </chkrun:checkReport>
+</chkrun:checkRunReports>`))
+		case r.URL.Path == programsEndpoint && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated) // create temp program
+		case strings.HasSuffix(r.URL.Path, "/source/main"):
+			if r.Method == http.MethodGet {
+				w.Header().Set("ETag", "etag-1")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("REPORT zx."))
+			} else { // PUT set-source
+				w.WriteHeader(http.StatusOK)
+			}
+		case r.URL.Query().Get("_action") == "LOCK":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>lh-1</LOCK_HANDLE></DATA></asx:values></asx:abap>`))
+		case r.URL.Query().Get("_action") == "UNLOCK":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestVerifySource(t *testing.T) {
+	t.Run("valid source (no error messages)", func(t *testing.T) {
+		srv := verifySourceServer(false)
+		defer srv.Close()
+		cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+		client := adt.NewClient(cfg)
+
+		valid, msgs, err := client.VerifySource(context.Background(), "REPORT zx.")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !valid {
+			t.Errorf("valid = false, want true (no error messages)")
+		}
+		if len(msgs) != 0 {
+			t.Errorf("expected 0 messages, got %d: %+v", len(msgs), msgs)
+		}
+	})
+
+	t.Run("invalid source (error message)", func(t *testing.T) {
+		srv := verifySourceServer(true)
+		defer srv.Close()
+		cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+		client := adt.NewClient(cfg)
+
+		valid, msgs, err := client.VerifySource(context.Background(), "REPORT zx. DATA x TYPE foo.")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if valid {
+			t.Errorf("valid = true, want false (an E message is present)")
+		}
+		if len(msgs) != 1 || msgs[0].Type != "E" {
+			t.Fatalf("expected 1 E message, got %+v", msgs)
+		}
+	})
+}


### PR DESCRIPTION
## What

Adds `VerifySource(ctx, source string) (valid bool, messages []SyntaxMessage, err error)` (`adt/verify.go`), on `QualityClient`. It creates a temporary program in `$TMP`, writes the source, runs an inactive-version syntax check, and deletes the temp program (defer). `valid` is true when there are no `"E"` messages. Added to `ClientRegistry` and the custexport mock.

## Why

mcp-server-abap's `verify_source` tool implements this ~8-call create→lock→set-source→check→delete dance inline, with the hardcoded `$TMP` package, temp-program naming, and `Type=="E"` mapping — an ADT idiom that belongs here. The inline-checkrun alternative was found unavailable on ECC/S4 (mcp-server-abap#126), so the throwaway-`$TMP` round-trip is the portable implementation.

Closes #87. Consumer: Hochfrequenz/aibap.mcp#415.

## Tests

`adt/verify_test.go` mocks the full round-trip (CSRF, create, lock, get-source-for-etag, set-source, unlock, /checkruns, delete). The `/checkruns` handler echoes the requested object URI as the report's `triggeringUri` (which `SyntaxCheck` correlates on — the program name is random) and conditionally includes one `E` message. Covers `valid=true` (no messages) and `valid=false` (one `E`).

`go test ./...` green; `go vet` clean; `golangci-lint --enable dupl,goconst,gocyclo` → 0 issues; `go build -tags integration ./adt/...` compiles.

No live integration test here: the dance composes already-integration-tested primitives; the end-to-end behavior is exercised by the #415 consumer reproducer on bump (valid + deliberately-broken source on hfq/s4u).

## Notes

- Temp name `Z_ADTLER_VERIFY_%06d` (random; not security-sensitive — `//nolint:gosec`).
- Interface addition to `QualityClient`: the consumer's `mockClient` will need `VerifySource` in the #415 bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)