### PR TITLE
fix(#436): omit If-Match on locked class-include writes

### DIFF
--- a/adt/source.go
+++ b/adt/source.go
@@ -270,7 +270,17 @@ func (c *httpClient) SetIncludeSource(ctx context.Context, objectURI, include, s
 		"Accept":                ct,
 		"X-sap-adt-sessiontype": "stateful",
 	}
-	if etag != "" {
+	// aibap.mcp#436: class include write-preconditions validate against a
+	// class-level version ETag that no include-or-class GET exposes — the GET
+	// returns a stale / wrong-granularity ETag, so a GET-derived If-Match
+	// deterministically fails with 412 ExceptionPreconditionFailed. A held lock
+	// already guarantees exclusive edit access, so when a lock handle is present
+	// we omit If-Match and rely on the lock for concurrency, matching how the
+	// Eclipse ADT client writes includes. Verified live on S/4: with a lock
+	// handle, a no-If-Match write succeeds where both the include ETag and the
+	// class ETag return 412. Without a lock handle we keep If-Match as a
+	// best-effort optimistic-concurrency check.
+	if etag != "" && lockHandle == "" {
 		headers["If-Match"] = etag
 	}
 	// Include endpoints expect lockHandle as query parameter, not header.

--- a/adt/source_include_integration_test.go
+++ b/adt/source_include_integration_test.go
@@ -72,3 +72,39 @@ func TestCreateAndWriteTestInclude_Integration(t *testing.T) {
 	}
 	t.Logf("testclasses: %d bytes, etag=%s", len(result.Source), result.ETag)
 }
+
+// TestSetIncludeSource_WithGetDerivedETag_Integration is the regression guard for
+// aibap.mcp#436. It reproduces the exact failing pattern the MCP wrapper produced:
+// GET the include (capturing its ETag), then write it back passing that ETag AND a
+// lock handle. Before the fix this returned 412 ExceptionPreconditionFailed because
+// the GET-derived ETag never matches SAP's class-level write precondition. After the
+// fix, SetIncludeSource omits If-Match when a lock handle is present and the write
+// succeeds. The pre-fix path (etag="") is already covered by the test above; this one
+// specifically feeds a non-empty GET-derived ETag, which is what actually broke.
+func TestSetIncludeSource_WithGetDerivedETag_Integration(t *testing.T) {
+	client := newIntegrationClient(t)
+	ctx := context.Background()
+
+	lockHandle, err := client.LockObject(ctx, testClassURI)
+	if err != nil {
+		t.Fatalf("LockObject: %v", err)
+	}
+	defer func() { _ = client.UnlockObject(ctx, testClassURI, lockHandle) }()
+
+	const include = "testclasses"
+	before, err := client.GetIncludeSource(ctx, testClassURI, include)
+	if err != nil {
+		t.Fatalf("GetIncludeSource(%s): %v", include, err)
+	}
+	if before.ETag == "" {
+		t.Fatalf("GetIncludeSource returned empty ETag — cannot exercise the #436 path")
+	}
+	t.Logf("GET-derived ETag: %s", before.ETag)
+
+	// Write the same source back, feeding the GET-derived ETag + lock handle.
+	// This is the call that returned 412 before the fix.
+	if _, err := client.SetIncludeSource(ctx, testClassURI, include, before.Source, lockHandle, "", before.ETag); err != nil {
+		t.Fatalf("SetIncludeSource with GET-derived ETag failed (regression of #436): %v", err)
+	}
+	t.Log("SetIncludeSource with GET-derived ETag + lock: OK")
+}

--- a/adt/source_test.go
+++ b/adt/source_test.go
@@ -146,6 +146,78 @@ func TestSetIncludeSource_NoETag(t *testing.T) {
 	}
 }
 
+func TestSetIncludeSource_OmitsIfMatchWhenLocked(t *testing.T) {
+	// aibap.mcp#436: with a lock handle, SetIncludeSource must NOT send If-Match
+	// (the GET-derived ETag never matches SAP's class-level write precondition,
+	// causing 412). The lock query parameter must still be sent.
+	var gotIfMatch, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		gotIfMatch = r.Header.Get("If-Match")
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("ETag", `"etag-new"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	// Locked write WITH a transport — the full real-world shape. If-Match must be
+	// omitted, and both lockHandle and corrNr must ride the query string.
+	newETag, err := client.SetIncludeSource(context.Background(),
+		"/sap/bc/adt/oo/classes/zcl_test", "testclasses",
+		"CLASS lcl_test DEFINITION FOR TESTING.\nENDCLASS.", "LOCKHANDLE123", "TR123", `"etag-old"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotIfMatch != "" {
+		t.Errorf("If-Match should be omitted when a lock handle is present, got %q", gotIfMatch)
+	}
+	if !strings.Contains(gotQuery, "lockHandle=LOCKHANDLE123") {
+		t.Errorf("lockHandle query param missing, got query %q", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "corrNr=TR123") {
+		t.Errorf("corrNr query param missing, got query %q", gotQuery)
+	}
+	if newETag != `"etag-new"` {
+		t.Errorf("returned ETag: got %q, want %q", newETag, `"etag-new"`)
+	}
+}
+
+func TestSetIncludeSource_KeepsIfMatchWhenUnlocked(t *testing.T) {
+	// Without a lock handle, If-Match is still sent as a best-effort optimistic
+	// concurrency check (unchanged behavior).
+	var gotIfMatch string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		gotIfMatch = r.Header.Get("If-Match")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	_, err := client.SetIncludeSource(context.Background(),
+		"/sap/bc/adt/oo/classes/zcl_test", "testclasses",
+		"CLASS lcl_test DEFINITION FOR TESTING.\nENDCLASS.", "", "", `"etag-old"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotIfMatch != `"etag-old"` {
+		t.Errorf("If-Match should be sent when unlocked, got %q", gotIfMatch)
+	}
+}
+
 func TestSetSource(t *testing.T) {
 	var gotMethod, gotIfMatch, gotContentType, gotBody string
 

--- a/adt/source_test.go
+++ b/adt/source_test.go
@@ -118,7 +118,11 @@ func TestSetIncludeSource(t *testing.T) {
 	}
 }
 
-func TestSetIncludeSource_NoETag(t *testing.T) {
+// captureIncludeIfMatch runs SetIncludeSource against a stub server that records
+// the If-Match request header, and returns what was sent. Shared by the
+// If-Match behaviour tests so they don't each repeat the stub-server boilerplate.
+func captureIncludeIfMatch(t *testing.T, lockHandle, etag string) string {
+	t.Helper()
 	var gotIfMatch string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == csrfEndpoint {
@@ -133,16 +137,18 @@ func TestSetIncludeSource_NoETag(t *testing.T) {
 
 	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
 	client := adt.NewClient(cfg)
-
-	// Empty etag = initial write on empty include
-	_, err := client.SetIncludeSource(context.Background(),
+	if _, err := client.SetIncludeSource(context.Background(),
 		"/sap/bc/adt/oo/classes/zcl_test", "testclasses",
-		"CLASS lcl_test DEFINITION FOR TESTING.\nENDCLASS.", "", "", "")
-	if err != nil {
+		"CLASS lcl_test DEFINITION FOR TESTING.\nENDCLASS.", lockHandle, "", etag); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gotIfMatch != "" {
-		t.Errorf("If-Match should be empty for initial write, got %q", gotIfMatch)
+	return gotIfMatch
+}
+
+func TestSetIncludeSource_NoETag(t *testing.T) {
+	// Empty etag (initial write on an empty include) → no If-Match.
+	if got := captureIncludeIfMatch(t, "", ""); got != "" {
+		t.Errorf("If-Match should be empty for initial write, got %q", got)
 	}
 }
 
@@ -190,31 +196,10 @@ func TestSetIncludeSource_OmitsIfMatchWhenLocked(t *testing.T) {
 }
 
 func TestSetIncludeSource_KeepsIfMatchWhenUnlocked(t *testing.T) {
-	// Without a lock handle, If-Match is still sent as a best-effort optimistic
-	// concurrency check (unchanged behavior).
-	var gotIfMatch string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == csrfEndpoint {
-			w.Header().Set("X-CSRF-Token", "token")
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		gotIfMatch = r.Header.Get("If-Match")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
-	client := adt.NewClient(cfg)
-
-	_, err := client.SetIncludeSource(context.Background(),
-		"/sap/bc/adt/oo/classes/zcl_test", "testclasses",
-		"CLASS lcl_test DEFINITION FOR TESTING.\nENDCLASS.", "", "", `"etag-old"`)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if gotIfMatch != `"etag-old"` {
-		t.Errorf("If-Match should be sent when unlocked, got %q", gotIfMatch)
+	// Without a lock handle there is no exclusivity guarantee, so If-Match is
+	// still sent as a best-effort optimistic-concurrency check (unchanged).
+	if got := captureIncludeIfMatch(t, "", `"etag-old"`); got != `"etag-old"` {
+		t.Errorf("If-Match should be sent when unlocked, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Fixes the class-include half of aibap.mcp#436.

## Problem

Editing a class include (`testclasses`/`implementations`/`definitions`/`macros`) via `SetIncludeSource` failed **deterministically** with `412 ExceptionPreconditionFailed`. The ETag returned by `GetIncludeSource` — and even the class-level `GetSource` ETag — is never the version ETag SAP validates the include write-precondition against. No include-or-class GET exposes that ETag.

## Evidence (live, S/4)

With a lock handle held:
| If-Match source | Result |
|---|---|
| include's own ETag | 412 |
| class-level ETag | 412 |
| **none** | **200 ✅** |

## Fix

A held lock already guarantees exclusive edit access, so when a lock handle is present, omit `If-Match` and rely on the lock — the same way the Eclipse ADT client writes includes. Without a lock handle, keep `If-Match` as a best-effort optimistic check (unchanged). **Scoped to `SetIncludeSource`; `SetSource` untouched.**

## Tests

- Unit: locked → no `If-Match` (lockHandle+corrNr still in query, returned ETag intact); unlocked → keeps `If-Match`.
- Integration (live S/4): feed a GET-derived ETag + lock handle → write succeeds (412 before, OK after).

Consumed by aibap.mcp; pairs with aibap.mcp#401 (wrapper resolves the lock handle so this path is actually exercised).