### PR TITLE
fix(#383): DDLS lock handle via query param, omit If-Match when locked

### DIFF
--- a/adt/ddls_source_integration_test.go
+++ b/adt/ddls_source_integration_test.go
@@ -19,15 +19,14 @@ func TestSetSource_DDLS_Integration(t *testing.T) {
 
 	const name = "Z_ADT_MCP_CDS383"
 	const uri = "/sap/bc/adt/ddic/ddl/sources/z_adt_mcp_cds383"
-	const pkg = "Z_ADT_MCP_TEST"
 	cds := "@EndUserText.label: 'aibap 383 regression'\n" +
 		"define root view entity Z_ADT_MCP_CDS383\n  as select from t000\n{\n  key mandt as Client\n}\n"
 
-	tr, err := client.CreateTransport(ctx, "K", "", "aibap #383 DDLS regression", pkg)
+	tr, err := client.CreateTransport(ctx, "K", "", "aibap #383 DDLS regression", testPackage)
 	if err != nil {
 		t.Fatalf("CreateTransport: %v", err)
 	}
-	if err := client.CreateObject(ctx, "DDLS", name, pkg, "aibap #383 DDLS regression", tr); err != nil {
+	if err := client.CreateObject(ctx, "DDLS", name, testPackage, "aibap #383 DDLS regression", tr); err != nil {
 		if _, e := client.GetObjectInfo(ctx, uri); e != nil {
 			t.Fatalf("CreateObject(DDLS): %v", err)
 		}

--- a/adt/ddls_source_integration_test.go
+++ b/adt/ddls_source_integration_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+
+package adt_test
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSetSource_DDLS_Integration is the regression guard for aibap.mcp#383's
+// DDLS symptom: before the fix, writing a CDS view's source via SetSource failed
+// with 403 ExceptionResourceNoAccess ("currently editing") because adtler
+// delivered the lock handle as a header (DDLS needs it as a ?lockHandle= query
+// param, and the header-first path 400/403s without triggering the 423 retry).
+// After the fix, the locked write succeeds.
+func TestSetSource_DDLS_Integration(t *testing.T) {
+	client := newIntegrationClient(t) // default = HF S/4 Mandant 100
+	ctx := context.Background()
+
+	const name = "Z_ADT_MCP_CDS383"
+	const uri = "/sap/bc/adt/ddic/ddl/sources/z_adt_mcp_cds383"
+	const pkg = "Z_ADT_MCP_TEST"
+	cds := "@EndUserText.label: 'aibap 383 regression'\n" +
+		"define root view entity Z_ADT_MCP_CDS383\n  as select from t000\n{\n  key mandt as Client\n}\n"
+
+	tr, err := client.CreateTransport(ctx, "K", "", "aibap #383 DDLS regression", pkg)
+	if err != nil {
+		t.Fatalf("CreateTransport: %v", err)
+	}
+	if err := client.CreateObject(ctx, "DDLS", name, pkg, "aibap #383 DDLS regression", tr); err != nil {
+		if _, e := client.GetObjectInfo(ctx, uri); e != nil {
+			t.Fatalf("CreateObject(DDLS): %v", err)
+		}
+		t.Log("DDLS exists, reusing")
+	}
+	t.Cleanup(func() { _ = client.DeleteObject(context.Background(), uri, "", tr) })
+
+	lockHandle, err := client.LockObject(ctx, uri)
+	if err != nil {
+		t.Fatalf("LockObject: %v", err)
+	}
+	defer func() { _ = client.UnlockObject(context.Background(), uri, lockHandle) }()
+
+	src, err := client.GetSource(ctx, uri)
+	if err != nil {
+		t.Fatalf("GetSource: %v", err)
+	}
+
+	// The write that returned 403 before the fix.
+	if _, err := client.SetSource(ctx, uri, cds, lockHandle, tr, src.ETag); err != nil {
+		t.Fatalf("SetSource on DDLS failed (regression of #383): %v", err)
+	}
+	t.Log("SetSource on DDLS with lock: OK")
+}

--- a/adt/source.go
+++ b/adt/source.go
@@ -351,9 +351,32 @@ func (c *httpClient) SetSource(ctx context.Context, objectURI, source, lockHandl
 	return c.trySetSource(ctx, objectURI, source, lockHandle, transport, etag)
 }
 
+// isDDLSourceURI reports whether objectURI is a DDL source (CDS view / DDLS).
+func isDDLSourceURI(objectURI string) bool {
+	return strings.HasPrefix(objectURI, "/sap/bc/adt/ddic/ddl/sources/")
+}
+
 // trySetSource attempts SetSource with the lock handle retry
 // (header-first for R/3, query-param retry for S/4).
 func (c *httpClient) trySetSource(ctx context.Context, objectURI, source, lockHandle, transport, etag string) (string, error) {
+	// DDL sources (CDS views) are S/4-only and behave like class includes, not
+	// like programs: the lock handle must be delivered as the ?lockHandle= query
+	// parameter, and the header-first attempt fails with 400/403 (not 423), so
+	// the generic retry-on-423 below never fires — every DDLS write is rejected
+	// as "currently editing" (aibap.mcp#383). The lock already guarantees
+	// exclusivity, so when locked we omit If-Match and rely on the lock — the
+	// shape proven to work. Verified live on S/4: a query-param write with no
+	// If-Match succeeds where header delivery returns 400/403. (Query delivery
+	// WITH a GET-derived If-Match was not separately probed; omitting is the
+	// proven-safe choice, consistent with the class-include fix for #436, where
+	// the GET ETag was shown not to be the write-precondition ETag.)
+	if isDDLSourceURI(objectURI) {
+		ddlsETag := etag
+		if lockHandle != "" {
+			ddlsETag = ""
+		}
+		return c.setSourceWithLockParam(ctx, objectURI, source, lockHandle, transport, ddlsETag)
+	}
 	newETag, err := c.setSourceWithLockHeader(ctx, objectURI, source, lockHandle, transport, etag)
 	if err != nil && lockHandle != "" && isInvalidLockHandle(err) {
 		return c.setSourceWithLockParam(ctx, objectURI, source, lockHandle, transport, etag)
@@ -366,8 +389,12 @@ func (c *httpClient) setSourceWithLockHeader(ctx context.Context, objectURI, sou
 	headers := map[string]string{
 		"Content-Type":          ct,
 		"Accept":                ct,
-		"If-Match":              etag,
 		"X-sap-adt-sessiontype": "stateful",
+	}
+	// Only send If-Match when we actually have an ETag — never an empty one,
+	// which some SAP versions treat as a failing precondition.
+	if etag != "" {
+		headers["If-Match"] = etag
 	}
 	if lockHandle != "" {
 		headers["X-SAP-Lock-Handle"] = lockHandle
@@ -384,8 +411,12 @@ func (c *httpClient) setSourceWithLockParam(ctx context.Context, objectURI, sour
 	headers := map[string]string{
 		"Content-Type":          ct,
 		"Accept":                ct,
-		"If-Match":              etag,
 		"X-sap-adt-sessiontype": "stateful",
+	}
+	// Only send If-Match when we actually have an ETag — never an empty one.
+	// DDL sources deliberately pass "" when locked (see trySetSource).
+	if etag != "" {
+		headers["If-Match"] = etag
 	}
 	params := url.Values{}
 	if lockHandle != "" {

--- a/adt/source_test.go
+++ b/adt/source_test.go
@@ -200,6 +200,87 @@ func TestSetSource(t *testing.T) {
 	}
 }
 
+func TestSetSource_DDLSUsesQueryLockDeliveryAndOmitsIfMatch(t *testing.T) {
+	// aibap.mcp#383: DDL sources need the lock handle as a ?lockHandle= query
+	// param (header delivery 400/403s and never triggers the 423 retry), and
+	// reject the GET-derived If-Match (#436-style), so it must be omitted when
+	// locked. Contrast the program path (TestSetSource), which keeps both.
+	var gotMethod, gotQuery, gotIfMatch, gotLockHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		gotMethod = r.Method
+		gotQuery = r.URL.RawQuery
+		gotIfMatch = r.Header.Get("If-Match")
+		gotLockHeader = r.Header.Get("X-SAP-Lock-Handle")
+		w.Header().Set("ETag", `"new-etag"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	_, err := client.SetSource(context.Background(),
+		"/sap/bc/adt/ddic/ddl/sources/zmycds",
+		"define root view entity ZMYCDS as select from t000 { key mandt as Client }",
+		"LOCKHANDLE1", "TR1", `"etag-from-get"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method: got %q, want PUT", gotMethod)
+	}
+	if !strings.Contains(gotQuery, "lockHandle=LOCKHANDLE1") {
+		t.Errorf("lock handle must be a query param for DDLS; query=%q", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "corrNr=TR1") {
+		t.Errorf("corrNr must be a query param; query=%q", gotQuery)
+	}
+	if gotIfMatch != "" {
+		t.Errorf("If-Match must be omitted for a locked DDLS write, got %q", gotIfMatch)
+	}
+	if gotLockHeader != "" {
+		t.Errorf("X-SAP-Lock-Handle header must NOT be used for DDLS, got %q", gotLockHeader)
+	}
+}
+
+func TestSetSource_DDLSUnlockedKeepsIfMatch(t *testing.T) {
+	// Without a lock handle there is nothing enforcing exclusivity, so a DDLS
+	// write still sends the caller's If-Match as a best-effort check (and still
+	// uses query delivery — no lock header).
+	var gotIfMatch, gotLockHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		gotIfMatch = r.Header.Get("If-Match")
+		gotLockHeader = r.Header.Get("X-SAP-Lock-Handle")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	_, err := client.SetSource(context.Background(),
+		"/sap/bc/adt/ddic/ddl/sources/zmycds", "define ...", "", "", `"etag-x"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotIfMatch != `"etag-x"` {
+		t.Errorf("unlocked DDLS write should keep If-Match, got %q", gotIfMatch)
+	}
+	if gotLockHeader != "" {
+		t.Errorf("X-SAP-Lock-Handle header must NOT be used for DDLS, got %q", gotLockHeader)
+	}
+}
+
 func TestSourceContentType_DiscoveryEmpty_FallsBackToTextPlain(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Empty discovery response


### PR DESCRIPTION
Fixes the DDLS symptom of aibap.mcp#383 (403 "currently editing" on CDS-view source writes).

## Root cause (raw-HTTP probe on S/4)

`SetSource` delivers the lock handle **header-first** (`X-SAP-Lock-Handle`) and only retries with `?lockHandle=` **on a 423**. DDLS rejects header delivery with **400/403 (not 423)**, so the query retry never fires and every DDLS write is rejected.

| Delivery (same lock) | Result |
|---|---|
| header-only | 400 |
| **query-only, no If-Match** | **200 ✅** |

## Fix

DDL sources behave like class includes, not programs: route DDL-source URIs to query-param lock delivery, and omit `If-Match` when locked (lock enforces exclusivity; the GET ETag is unusable, same as #436). DDLS is **S/4-only**, so no R/3 regression; the program path (header-first + retry-on-423) is untouched. Also stop sending an empty `If-Match` (some SAP versions treat it as a failing precondition).

## Scope / not included

Only DDLS is routed (the only type proven to need it). DDLX/DCLS aren't writable by this client; the un-diagnosed CLAS/INTF create→write 403 is a separate issue. A future generalization could retry on 400/403-with-lock rather than a URI allowlist.

## Tests

- Unit: DDLS locked → query delivery, no `If-Match`, no lock header; DDLS unlocked → keeps `If-Match`; program path unchanged.
- Integration (live S/4): DDLS create → locked `SetSource` succeeds (403 before, OK after).