### PR TITLE
feat: classrun endpoint (RunClass) — spec, plan, and implementation

### DIFF
--- a/adt/classrun.go
+++ b/adt/classrun.go
@@ -1,0 +1,50 @@
+package adt
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ClassRunResult holds the console output produced by executing a global ABAP
+// class via the classrun endpoint ("Run as ABAP Application").
+type ClassRunResult struct {
+	ClassName     string `json:"class_name"`
+	ConsoleOutput string `json:"console_output"`
+}
+
+// ClassRunClient executes global ABAP classes that implement IF_OO_ADT_CLASSRUN.
+type ClassRunClient interface {
+	// RunClass executes the global class className via the ADT classrun
+	// endpoint and returns whatever the class writes to the console handler
+	// (out->write(...)). It does not validate that the class exists, is
+	// active, or implements IF_OO_ADT_CLASSRUN — the caller pre-checks that.
+	RunClass(ctx context.Context, className string) (*ClassRunResult, error)
+}
+
+// RunClass POSTs to /sap/bc/adt/oo/classrun/{name} (name lower-cased) with an
+// empty body and Accept: text/plain, and returns the class's console output.
+//
+// The session is stateless: classrun only executes the class; any locking or
+// commit the class performs is the class's own concern. Namespace slashes in
+// className are percent-encoded automatically by doMutate → encodeNamespacePath
+// (triggered by the "//" that results from appending "/na2/foo" to the base).
+func (c *httpClient) RunClass(ctx context.Context, className string) (*ClassRunResult, error) {
+	uri := "/sap/bc/adt/oo/classrun/" + strings.ToLower(className)
+	resp, err := c.doMutate(ctx, http.MethodPost, uri, nil,
+		map[string]string{"Accept": contentTypeTextPlain})
+	if err != nil {
+		return nil, fmt.Errorf("RunClass: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if err := checkResponse(resp); err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("RunClass reading body: %w", err)
+	}
+	return &ClassRunResult{ClassName: className, ConsoleOutput: string(body)}, nil
+}

--- a/adt/classrun_integration_test.go
+++ b/adt/classrun_integration_test.go
@@ -38,10 +38,13 @@ func TestRunClass_Integration(t *testing.T) {
 	for _, sys := range eachSystem(t) {
 		sys := sys
 		t.Run(sys.Name, func(t *testing.T) {
-			ctx := context.Background()
 			if _, err := sys.Client.GetObjectInfo(ctx, classrunClassURI(classrunFixture)); err != nil {
-				t.Skipf("classrun fixture %s not present on %s (deliver it to Z_ADT_MCP_TEST first): %v",
-					classrunFixture, sys.Name, err)
+				var adtErr *adt.ADTError
+				if errors.As(err, &adtErr) && adtErr.StatusCode == 404 {
+					t.Skipf("classrun fixture %s not present on %s (deliver it to Z_ADT_MCP_TEST first): %v",
+						classrunFixture, sys.Name, err)
+				}
+				t.Fatalf("GetObjectInfo pre-check for %s on %s failed: %v", classrunFixture, sys.Name, err)
 			}
 			result, err := sys.Client.RunClass(ctx, classrunFixture)
 			if err != nil {

--- a/adt/classrun_integration_test.go
+++ b/adt/classrun_integration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package adt_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+)
+
+// classrunFixture is the global class in Z_ADT_MCP_TEST that implements
+// IF_OO_ADT_CLASSRUN and writes classrunFixtureOutput to the console.
+const (
+	classrunFixture       = "ZCL_ADT_MCP_CLASSRUN_TST"
+	classrunFixtureOutput = "CLASSRUN_OK"
+	classrunThrowFixture  = "ZCL_ADT_MCP_CLASSRUN_ERR"
+)
+
+// classrunClassURI returns the ADT class URI for a classrun fixture name.
+func classrunClassURI(name string) string {
+	return "/sap/bc/adt/oo/classes/" + strings.ToLower(name)
+}
+
+// TestRunClass_Integration runs a real classrun class on every whitelisted
+// system (R/3 and S/4 via eachSystem) and asserts the known console string
+// comes back. This also exercises the classrun framework on each system —
+// the endpoint handler CL_OO_ADT_RES_CLASSRUN is present on both HFQ/ECC and
+// S4U (spec open verification point #2, resolved).
+//
+// The fixture-existence pre-check uses GetObjectInfo, NOT a 404 from RunClass:
+// the handler returns HTTP 200 with an error string for a missing/invalid
+// class (verified against CL_OO_ADT_RES_CLASSRUN), so a missing fixture would
+// otherwise fail the ConsoleOutput assertion instead of skipping cleanly.
+func TestRunClass_Integration(t *testing.T) {
+	for _, sys := range eachSystem(t) {
+		sys := sys
+		t.Run(sys.Name, func(t *testing.T) {
+			ctx := context.Background()
+			if _, err := sys.Client.GetObjectInfo(ctx, classrunClassURI(classrunFixture)); err != nil {
+				t.Skipf("classrun fixture %s not present on %s (deliver it to Z_ADT_MCP_TEST first): %v",
+					classrunFixture, sys.Name, err)
+			}
+			result, err := sys.Client.RunClass(ctx, classrunFixture)
+			if err != nil {
+				t.Fatalf("RunClass on %s failed: %v", sys.Name, err)
+			}
+			if !strings.Contains(result.ConsoleOutput, classrunFixtureOutput) {
+				t.Errorf("%s: console output %q does not contain %q",
+					sys.Name, result.ConsoleOutput, classrunFixtureOutput)
+			}
+			t.Logf("%s classrun output: %q", sys.Name, result.ConsoleOutput)
+		})
+	}
+}
+
+// TestRunClass_ThrowingClass confirms how an uncaught runtime exception in
+// main() is signalled — spec open verification point #1. Verified against
+// CL_OO_ADT_RES_CLASSRUN: main() runs inside a TRY that catches only
+// cx_sy_create_object_error, so a genuine uncaught runtime exception (e.g.
+// cx_sy_zerodivide) propagates and the ADT REST framework turns it into a
+// non-2xx HTTP error -> *adt.ADTError. "Soft" failures (missing S_DEVELOP
+// auth, class does not implement the interface) instead come back as HTTP 200
+// with the error text in the body.
+//
+// The test therefore EXPECTS an ADTError for the throwing fixture, and logs
+// the observed status/body so the exact status code can be pinned. If the
+// fixture instead returns 200, that means it failed "softly" rather than
+// throwing — adjust the fixture, not the client.
+func TestRunClass_ThrowingClass(t *testing.T) {
+	for _, sys := range eachSystem(t) {
+		sys := sys
+		t.Run(sys.Name, func(t *testing.T) {
+			ctx := context.Background()
+			if _, err := sys.Client.GetObjectInfo(ctx, classrunClassURI(classrunThrowFixture)); err != nil {
+				t.Skipf("throwing fixture %s not present on %s: %v",
+					classrunThrowFixture, sys.Name, err)
+			}
+			result, err := sys.Client.RunClass(ctx, classrunThrowFixture)
+			if err == nil {
+				t.Logf("%s: throwing class returned HTTP 200 (soft failure), body: %q",
+					sys.Name, result.ConsoleOutput)
+				return
+			}
+			var adtErr *adt.ADTError
+			if !errors.As(err, &adtErr) {
+				t.Fatalf("%s: expected *adt.ADTError, got %T: %v", sys.Name, err, err)
+			}
+			t.Logf("%s: throwing class surfaced as ADTError, status %d: %s",
+				sys.Name, adtErr.StatusCode, adtErr.Message)
+			if adtErr.StatusCode < 500 {
+				t.Logf("%s: NOTE status %d is below 5xx — record it and tighten this assertion",
+					sys.Name, adtErr.StatusCode)
+			}
+		})
+	}
+}

--- a/adt/classrun_integration_test.go
+++ b/adt/classrun_integration_test.go
@@ -83,9 +83,8 @@ func TestRunClass_ThrowingClass(t *testing.T) {
 			}
 			result, err := sys.Client.RunClass(ctx, classrunThrowFixture)
 			if err == nil {
-				t.Logf("%s: throwing class returned HTTP 200 (soft failure), body: %q",
+				t.Fatalf("%s: expected RunClass to fail for throwing fixture, got HTTP 200 body: %q",
 					sys.Name, result.ConsoleOutput)
-				return
 			}
 			var adtErr *adt.ADTError
 			if !errors.As(err, &adtErr) {

--- a/adt/classrun_test.go
+++ b/adt/classrun_test.go
@@ -1,0 +1,162 @@
+package adt_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+	sapmcpconfig "github.com/Hochfrequenz/sap-mcp-config"
+)
+
+// classrunBase is the classrun endpoint prefix. The class name is lower-cased
+// and appended to it.
+const classrunBase = "/sap/bc/adt/oo/classrun/"
+
+func TestRunClass_Success(t *testing.T) {
+	var gotMethod, gotPath, gotAccept, gotCSRF string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAccept = r.Header.Get("Accept")
+		gotCSRF = r.Header.Get("X-CSRF-Token")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Hello from classrun\n"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	result, err := client.RunClass(context.Background(), "ZCL_ADT_MCP_CLASSRUN_TST")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method: got %q, want POST", gotMethod)
+	}
+	if gotPath != classrunBase+"zcl_adt_mcp_classrun_tst" {
+		t.Errorf("path: got %q, want %q", gotPath, classrunBase+"zcl_adt_mcp_classrun_tst")
+	}
+	if gotAccept != "text/plain" {
+		t.Errorf("Accept: got %q, want text/plain", gotAccept)
+	}
+	if gotCSRF != "token" {
+		t.Errorf("X-CSRF-Token: got %q, want token", gotCSRF)
+	}
+	if len(gotBody) != 0 {
+		t.Errorf("body: got %q, want empty", gotBody)
+	}
+	if result.ClassName != "ZCL_ADT_MCP_CLASSRUN_TST" {
+		t.Errorf("ClassName: got %q", result.ClassName)
+	}
+	if result.ConsoleOutput != "Hello from classrun\n" {
+		t.Errorf("ConsoleOutput: got %q", result.ConsoleOutput)
+	}
+}
+
+// TestRunClass_UTF8 verifies that non-ASCII console output (Umlaute) survives
+// the text/plain round-trip intact.
+func TestRunClass_UTF8(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Grüße aus Köln — Größe: 42"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	result, err := client.RunClass(context.Background(), "ZCL_ADT_MCP_CLASSRUN_TST")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ConsoleOutput != "Grüße aus Köln — Größe: 42" {
+		t.Errorf("ConsoleOutput: got %q", result.ConsoleOutput)
+	}
+}
+
+// TestRunClass_Namespaced verifies that a namespaced class name is
+// percent-encoded (the "//" -> %2f..%2f path) before the request is sent.
+func TestRunClass_Namespaced(t *testing.T) {
+	var gotEscapedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		gotEscapedPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	result, err := client.RunClass(context.Background(), "/NA2/CL_FOO")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := classrunBase + "%2fna2%2fcl_foo"
+	if gotEscapedPath != want {
+		t.Errorf("escaped path: got %q, want %q", gotEscapedPath, want)
+	}
+	// ClassName echoes the caller's input verbatim (not lower-cased).
+	if result.ClassName != "/NA2/CL_FOO" {
+		t.Errorf("ClassName: got %q, want /NA2/CL_FOO", result.ClassName)
+	}
+}
+
+// TestRunClass_HTTPError verifies that a non-2xx response surfaces as an
+// *adt.ADTError with the status code and body message preserved.
+func TestRunClass_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("Not authorized to run class"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	_, err := client.RunClass(context.Background(), "ZCL_NOPE")
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var adtErr *adt.ADTError
+	if !errors.As(err, &adtErr) {
+		t.Fatalf("expected *adt.ADTError, got %T: %v", err, err)
+	}
+	if adtErr.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode: got %d, want 403", adtErr.StatusCode)
+	}
+	if !strings.Contains(adtErr.Message, "Not authorized to run class") {
+		t.Errorf("Message: got %q, want it to contain the body text", adtErr.Message)
+	}
+}

--- a/adt/client.go
+++ b/adt/client.go
@@ -186,6 +186,7 @@ type Client interface {
 	DumpClient
 	SystemClient
 	DependencyClient
+	ClassRunClient
 }
 
 type httpClient struct {

--- a/adt/custexport/export_test.go
+++ b/adt/custexport/export_test.go
@@ -24,6 +24,9 @@ func (m *mockClient) RunQuery(ctx context.Context, sql string, maxRows int) (*ad
 func (m *mockClient) GetObjectDependencies(context.Context, string, string, int, int) (*adt.DependencyResult, error) {
 	panic("not implemented")
 }
+func (m *mockClient) RunClass(context.Context, string) (*adt.ClassRunResult, error) {
+	panic("not implemented")
+}
 
 func (m *mockClient) GetSource(context.Context, string) (*adt.SourceResult, error) {
 	panic("not implemented")

--- a/adt/registry.go
+++ b/adt/registry.go
@@ -236,6 +236,9 @@ func (r *ClientRegistry) RunQuery(ctx context.Context, sql string, maxRows int) 
 func (r *ClientRegistry) GetObjectDependencies(ctx context.Context, objectType, objectName string, maxResults, maxDepth int) (*DependencyResult, error) {
 	return r.activeClient().GetObjectDependencies(ctx, objectType, objectName, maxResults, maxDepth)
 }
+func (r *ClientRegistry) RunClass(ctx context.Context, className string) (*ClassRunResult, error) {
+	return r.activeClient().RunClass(ctx, className)
+}
 func (r *ClientRegistry) GetEnhancementSpot(ctx context.Context, spotName string) (*EnhancementSpotInfo, error) {
 	return r.activeClient().GetEnhancementSpot(ctx, spotName)
 }

--- a/docs/superpowers/plans/2026-07-23-classrun-endpoint.md
+++ b/docs/superpowers/plans/2026-07-23-classrun-endpoint.md
@@ -1,0 +1,557 @@
+# `RunClass` — ADT Classrun endpoint client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `RunClass(ctx, className)` client method that POSTs to the ADT classrun endpoint (`/sap/bc/adt/oo/classrun/{name}`) and returns the executed class's console output.
+
+**Architecture:** A new `adt/classrun.go` holds the `ClassRunResult` type, the `ClassRunClient` interface, and the `(*httpClient).RunClass` implementation. `RunClass` follows the `GetSource`/`ActivateObjects` shape: build the URI, `doMutate` a POST with `Accept: text/plain` and an empty body, `checkResponse`, read the body in full, and return it as `ConsoleOutput`. `ClassRunClient` is embedded in the aggregate `Client` interface so the capability is reachable everywhere `adt.Client` is. Namespace slash-encoding is handled automatically by `doMutate` → `encodeNamespacePath`; no lock or session pinning is needed (classrun only executes).
+
+**Tech Stack:** Go 1.25+, `net/http`, `io`, `httptest` for unit tests, `eachSystem(t)` for multi-system integration tests. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md`
+
+**Branch:** Create `feat/classrun-endpoint` from `main` before Task 1 (`git checkout main && git pull && git checkout -b feat/classrun-endpoint`). The spec doc already lives on `docs/classrun-endpoint-spec`; the implementation is a separate PR per the one-PR-per-issue workflow. If an adtler issue number is assigned, rename the branch to `feat/<N>-classrun-endpoint`.
+
+## Execution Approach
+
+This plan is written to be executed **test-driven (TDD)** and **subagent-driven**. Both are mandatory, not optional.
+
+### Test-Driven Development (TDD)
+
+Every behaviour is built red → green → commit. Within each task the steps are ordered so the test always comes first:
+
+1. **Write the failing test** — the assertion that pins the behaviour.
+2. **Run it and confirm it fails** for the expected reason (the step states the exact expected failure, e.g. `RunClass undefined`). A test that passes before the implementation exists is a broken test — stop and fix it.
+3. **Write the minimal implementation** to make it pass — nothing the current test does not demand.
+4. **Run it and confirm it passes.**
+5. **Commit** at each green deliverable.
+
+Do not write implementation code ahead of its test, and do not batch multiple behaviours into one untested lump. If a step's actual output differs from its stated "Expected:", stop and reconcile before moving on. (Sub-skill: `superpowers:test-driven-development`.)
+
+### Subagent-Driven Execution
+
+Execute the plan with the `superpowers:subagent-driven-development` skill — one fresh subagent per task, with a review checkpoint between tasks:
+
+- **Dispatch:** hand each task to a fresh subagent with no prior conversation context. Give it only this plan, the spec (`docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md`), and the task boundary. The `Interfaces` block on each task tells the subagent the exact names/types its neighbours rely on, so it needs no other context.
+- **Task order:** Task 1 (client + unit tests) must be green and committed before Task 2 (integration tests) starts — Task 2 consumes `adt.Client.RunClass` from Task 1.
+- **Two-stage review between tasks:** after a subagent reports a task done, (1) a fresh reviewer subagent checks the diff against the task's spec/steps and coding standards, then (2) the orchestrator confirms the task's verification commands (`go test ./...`, `go build -tags integration ./adt/...`, `go vet -tags integration ./adt/...`) actually pass before dispatching the next task. Do not proceed on an unreviewed or red task.
+- **Isolation:** if tasks are run in parallel worktrees, Task 2 still gates on Task 1's merge because of the interface dependency — keep them sequential.
+
+## Global Constraints
+
+- **Go version floor:** 1.25+ (CI runs 1.25 and 1.26).
+- **No new dependencies.** Use only the standard library and existing `adt` package helpers.
+- **`Accept: text/plain` is hard-coded** via the existing `contentTypeTextPlain` constant (`adt/source.go:47`). Do NOT call `sourceContentType`/`NegotiateContentType` — discovery does an exact-key lookup that would never match the classrun per-object URI and silently fall back anyway.
+- **Stateless session.** No `X-sap-adt-sessiontype: stateful` header, no lock acquisition.
+- **Standard 30 s timeout** — use `doMutate` (default `c.http` client), not `doMutateLong`.
+- **Body decoded as `string(body)`** (like `GetSource`) so UTF-8 console output (Umlaute) round-trips.
+- **No ABAP source in Go test fixtures via backtick raw strings** (repo pitfall — irrelevant to unit tests here, but the integration fixture class lives in `Z_ADT_MCP_TEST`, not inline).
+- **goconst:** hoist any test string used 3+ times into a `const` (e.g. the classrun base path).
+- **Lint gate:** `golangci-lint run --enable dupl,goconst,gocyclo ./...` must pass.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `adt/classrun.go` | Create | `ClassRunResult` type, `ClassRunClient` interface, `(*httpClient).RunClass` implementation. |
+| `adt/client.go` | Modify (line 158-176) | Embed `ClassRunClient` in the aggregate `Client` interface. |
+| `adt/classrun_test.go` | Create | Unit tests (`httptest` mock, no build tag): success path, URI lower-casing, namespace encoding, UTF-8 round-trip, HTTP error. |
+| `adt/classrun_integration_test.go` | Create | `//go:build integration` multi-system test via `eachSystem(t)`: real class run, namespaced variant, throwing variant (resolves the open verification point). |
+
+Two reviewable units: Task 1 delivers the working client + full unit coverage; Task 2 delivers the integration tests (which depend on fixture delivery to `Z_ADT_MCP_TEST` and therefore carry the `needs:integration-test` label).
+
+---
+
+## Task 1: `RunClass` client method + unit tests
+
+**Files:**
+- Create: `adt/classrun.go`
+- Modify: `adt/client.go:158-176` (embed `ClassRunClient` in `Client`)
+- Create: `adt/classrun_test.go`
+
+**Interfaces:**
+- Consumes: `(*httpClient).doMutate` (`client.go:459`), `checkResponse` (`client.go:711`), `contentTypeTextPlain` (`source.go:47`), `encodeNamespacePath` (called automatically inside `doMutate`).
+- Produces:
+  - `type ClassRunResult struct { ClassName string; ConsoleOutput string }` (JSON tags `class_name`, `console_output`).
+  - `type ClassRunClient interface { RunClass(ctx context.Context, className string) (*ClassRunResult, error) }`.
+  - `func (c *httpClient) RunClass(ctx context.Context, className string) (*ClassRunResult, error)`.
+
+- [ ] **Step 1: Write the failing success-path test**
+
+Create `adt/classrun_test.go`:
+
+```go
+package adt_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+	sapmcpconfig "github.com/Hochfrequenz/sap-mcp-config"
+)
+
+// NOTE: `errors` and `strings` are added to this import block later, in Task 1
+// Step 10, when TestRunClass_HTTPError first uses them. Adding them now would
+// be an unused-import compile error and break Steps 5/7/9.
+
+// classrunBase is the classrun endpoint prefix. The class name is lower-cased
+// and appended to it.
+const classrunBase = "/sap/bc/adt/oo/classrun/"
+
+func TestRunClass_Success(t *testing.T) {
+	var gotMethod, gotPath, gotAccept, gotCSRF string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAccept = r.Header.Get("Accept")
+		gotCSRF = r.Header.Get("X-CSRF-Token")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Hello from classrun\n"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	result, err := client.RunClass(context.Background(), "ZCL_ADT_MCP_CLASSRUN_TST")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method: got %q, want POST", gotMethod)
+	}
+	if gotPath != classrunBase+"zcl_adt_mcp_classrun_tst" {
+		t.Errorf("path: got %q, want %q", gotPath, classrunBase+"zcl_adt_mcp_classrun_tst")
+	}
+	if gotAccept != "text/plain" {
+		t.Errorf("Accept: got %q, want text/plain", gotAccept)
+	}
+	if gotCSRF != "token" {
+		t.Errorf("X-CSRF-Token: got %q, want token", gotCSRF)
+	}
+	if len(gotBody) != 0 {
+		t.Errorf("body: got %q, want empty", gotBody)
+	}
+	if result.ClassName != "ZCL_ADT_MCP_CLASSRUN_TST" {
+		t.Errorf("ClassName: got %q", result.ClassName)
+	}
+	if result.ConsoleOutput != "Hello from classrun\n" {
+		t.Errorf("ConsoleOutput: got %q", result.ConsoleOutput)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./adt/ -run TestRunClass_Success`
+Expected: FAIL — compile error `client.RunClass undefined (type adt.Client has no field or method RunClass)`.
+
+- [ ] **Step 3: Create `adt/classrun.go` with the type, interface, and implementation**
+
+Create `adt/classrun.go`:
+
+```go
+package adt
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ClassRunResult holds the console output produced by executing a global ABAP
+// class via the classrun endpoint ("Run as ABAP Application").
+type ClassRunResult struct {
+	ClassName     string `json:"class_name"`
+	ConsoleOutput string `json:"console_output"`
+}
+
+// ClassRunClient executes global ABAP classes that implement IF_OO_ADT_CLASSRUN.
+type ClassRunClient interface {
+	// RunClass executes the global class className via the ADT classrun
+	// endpoint and returns whatever the class writes to the console handler
+	// (out->write(...)). It does not validate that the class exists, is
+	// active, or implements IF_OO_ADT_CLASSRUN — the caller pre-checks that.
+	RunClass(ctx context.Context, className string) (*ClassRunResult, error)
+}
+
+// RunClass POSTs to /sap/bc/adt/oo/classrun/{name} (name lower-cased) with an
+// empty body and Accept: text/plain, and returns the class's console output.
+//
+// The session is stateless: classrun only executes the class; any locking or
+// commit the class performs is the class's own concern. Namespace slashes in
+// className are percent-encoded automatically by doMutate → encodeNamespacePath
+// (triggered by the "//" that results from appending "/na2/foo" to the base).
+func (c *httpClient) RunClass(ctx context.Context, className string) (*ClassRunResult, error) {
+	uri := "/sap/bc/adt/oo/classrun/" + strings.ToLower(className)
+	resp, err := c.doMutate(ctx, http.MethodPost, uri, nil,
+		map[string]string{"Accept": contentTypeTextPlain})
+	if err != nil {
+		return nil, fmt.Errorf("RunClass: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if err := checkResponse(resp); err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("RunClass reading body: %w", err)
+	}
+	return &ClassRunResult{ClassName: className, ConsoleOutput: string(body)}, nil
+}
+```
+
+- [ ] **Step 4: Embed `ClassRunClient` in the aggregate `Client` interface**
+
+In `adt/client.go`, add `ClassRunClient` to the `Client` interface (the block at lines 158-176). Insert it alphabetically-adjacent to the other capability interfaces, e.g. after `DependencyClient`:
+
+```go
+// Client is the full ADT client combining all capabilities.
+type Client interface {
+	SourceClient
+	ObjectClient
+	LockClient
+	DocuClient
+	NavigationClient
+	SearchClient
+	DDICClient
+	QualityClient
+	RefactoringClient
+	VersionClient
+	TransportClient
+	ExportClient
+	QueryClient
+	EnhancementClient
+	DumpClient
+	SystemClient
+	DependencyClient
+	ClassRunClient
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `go test ./adt/ -run TestRunClass_Success -v`
+Expected: PASS.
+
+- [ ] **Step 6: Add the URI lower-casing + UTF-8 round-trip test**
+
+Append to `adt/classrun_test.go`:
+
+```go
+// TestRunClass_UTF8 verifies that non-ASCII console output (Umlaute) survives
+// the text/plain round-trip intact.
+func TestRunClass_UTF8(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Grüße aus Köln — Größe: 42"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	result, err := client.RunClass(context.Background(), "ZCL_ADT_MCP_CLASSRUN_TST")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ConsoleOutput != "Grüße aus Köln — Größe: 42" {
+		t.Errorf("ConsoleOutput: got %q", result.ConsoleOutput)
+	}
+}
+```
+
+- [ ] **Step 7: Run to verify it passes**
+
+Run: `go test ./adt/ -run TestRunClass_UTF8 -v`
+Expected: PASS.
+
+- [ ] **Step 8: Add the namespace-encoding test**
+
+The `//` produced by appending a lower-cased `/na2/foo` to the base triggers `encodeNamespacePath`, which percent-encodes the namespace slashes. The server sees the encoded form via `r.URL.EscapedPath()` (`r.URL.Path` would decode `%2f` back to `/`). Append to `adt/classrun_test.go`:
+
+```go
+// TestRunClass_Namespaced verifies that a namespaced class name is
+// percent-encoded (the "//" -> %2f..%2f path) before the request is sent.
+func TestRunClass_Namespaced(t *testing.T) {
+	var gotEscapedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		gotEscapedPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	result, err := client.RunClass(context.Background(), "/NA2/CL_FOO")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := classrunBase + "%2fna2%2fcl_foo"
+	if gotEscapedPath != want {
+		t.Errorf("escaped path: got %q, want %q", gotEscapedPath, want)
+	}
+	// ClassName echoes the caller's input verbatim (not lower-cased).
+	if result.ClassName != "/NA2/CL_FOO" {
+		t.Errorf("ClassName: got %q, want /NA2/CL_FOO", result.ClassName)
+	}
+}
+```
+
+- [ ] **Step 9: Run to verify it passes**
+
+Run: `go test ./adt/ -run TestRunClass_Namespaced -v`
+Expected: PASS. If `gotEscapedPath` comes back with `/` instead of `%2f`, the encoding did not trigger — re-check that `strings.ToLower` runs BEFORE the base is prepended so the `//` boundary exists.
+
+- [ ] **Step 10: Add the HTTP-error test**
+
+Append to `adt/classrun_test.go`:
+
+```go
+// TestRunClass_HTTPError verifies that a non-2xx response surfaces as an
+// *adt.ADTError with the status code and body message preserved.
+func TestRunClass_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == csrfEndpoint {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("Not authorized to run class"))
+	}))
+	defer srv.Close()
+
+	cfg := sapmcpconfig.SAPSystem{Host: srv.URL, User: "U", Password: "P", Client: "100"}
+	client := adt.NewClient(cfg)
+
+	_, err := client.RunClass(context.Background(), "ZCL_NOPE")
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var adtErr *adt.ADTError
+	if !errors.As(err, &adtErr) {
+		t.Fatalf("expected *adt.ADTError, got %T: %v", err, err)
+	}
+	if adtErr.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode: got %d, want 403", adtErr.StatusCode)
+	}
+	if !strings.Contains(adtErr.Message, "Not authorized to run class") {
+		t.Errorf("Message: got %q, want it to contain the body text", adtErr.Message)
+	}
+}
+```
+
+Note: this is the first test to use `errors` and `strings`. Add BOTH `"errors"` and `"strings"` to the import block of `adt/classrun_test.go` now (they were intentionally omitted in Step 1 to avoid an unused-import compile error). After this step the final import block is: `context`, `errors`, `io`, `net/http`, `net/http/httptest`, `strings`, `testing`, plus `adt` and `sapmcpconfig` — all used.
+
+- [ ] **Step 11: Run to verify it passes**
+
+Run: `go test ./adt/ -run TestRunClass_HTTPError -v`
+Expected: PASS.
+
+- [ ] **Step 12: Run the full unit suite, vet, build, and lint**
+
+Run:
+```bash
+go test ./...
+go vet ./...
+go build ./...
+golangci-lint run --enable dupl,goconst,gocyclo ./adt/...
+```
+Expected: all PASS / clean. If `goconst` flags the classrun path string, it is already hoisted to `classrunBase` in the test — the production side uses the literal only once, which is fine.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add adt/classrun.go adt/classrun_test.go adt/client.go
+git commit -m "feat: add RunClass client for ADT classrun endpoint"
+```
+
+---
+
+## Task 2: Multi-system integration tests
+
+**Files:**
+- Create: `adt/classrun_integration_test.go`
+
+**Interfaces:**
+- Consumes: `eachSystem(t)` (`integration_helpers_test.go:161`), `adt.Client.RunClass` (from Task 1), `adt.ADTError`. The fixture classes live in `testPackage` (`Z_ADT_MCP_TEST`) but are referenced by name via the `classrunFixture`/`classrunThrowFixture` consts, not through the `testPackage` symbol.
+- Produces: nothing consumed by later tasks. This task also **resolves open verification point #1** (runtime-exception signalling) and **#2** (classrun availability on HFQ/ECC) by observing live behaviour and updating the spec doc.
+
+**Precondition (ordering dependency):** The fixture classes must exist in `Z_ADT_MCP_TEST` before these tests can pass:
+- `ZCL_ADT_MCP_CLASSRUN_TST` — implements `IF_OO_ADT_CLASSRUN`; its `main` writes a known string (`out->write( 'CLASSRUN_OK' ).`).
+- A throwing variant, e.g. `ZCL_ADT_MCP_CLASSRUN_ERR` — its `main` raises an uncaught exception (`RAISE EXCEPTION TYPE cx_sy_zerodivide.` or similar).
+- (Optional, HFQ-specific) a namespaced variant `/NA2/CL_ADT_MCP_CLASSRUN` if the `/NA2/` namespace is available on the target system; otherwise the namespace encoding is already covered by the Task 1 unit test.
+
+These are delivered via the [Z_ADT_MCP_TEST](https://github.com/Hochfrequenz/Z_ADT_MCP_TEST) repo. If a fixture is missing on a system, the sub-test should `t.Skip` with a clear message rather than fail.
+
+- [ ] **Step 1: Write the happy-path integration test**
+
+Create `adt/classrun_integration_test.go`:
+
+```go
+//go:build integration
+
+package adt_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+)
+
+// classrunFixture is the global class in Z_ADT_MCP_TEST that implements
+// IF_OO_ADT_CLASSRUN and writes classrunFixtureOutput to the console.
+const (
+	classrunFixture       = "ZCL_ADT_MCP_CLASSRUN_TST"
+	classrunFixtureOutput = "CLASSRUN_OK"
+	classrunThrowFixture  = "ZCL_ADT_MCP_CLASSRUN_ERR"
+)
+
+// TestRunClass_Integration runs a real classrun class on every whitelisted
+// system (R/3 and S/4 via eachSystem) and asserts the known console string
+// comes back. This also confirms whether the classrun framework
+// (IF_OO_ADT_CLASSRUN) is available on each system — see spec open
+// verification point #2 (HFQ/ECC not previously verified).
+func TestRunClass_Integration(t *testing.T) {
+	for _, sys := range eachSystem(t) {
+		sys := sys
+		t.Run(sys.Name, func(t *testing.T) {
+			ctx := context.Background()
+			result, err := sys.Client.RunClass(ctx, classrunFixture)
+			if err != nil {
+				var adtErr *adt.ADTError
+				if errors.As(err, &adtErr) && adtErr.StatusCode == 404 {
+					t.Skipf("classrun fixture %s or endpoint not available on %s (404): %v",
+						classrunFixture, sys.Name, err)
+				}
+				t.Fatalf("RunClass on %s failed: %v", sys.Name, err)
+			}
+			if !strings.Contains(result.ConsoleOutput, classrunFixtureOutput) {
+				t.Errorf("%s: console output %q does not contain %q",
+					sys.Name, result.ConsoleOutput, classrunFixtureOutput)
+			}
+			t.Logf("%s classrun output: %q", sys.Name, result.ConsoleOutput)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Verify the integration file builds (without running against SAP)**
+
+Run:
+```bash
+go build -tags integration ./adt/...
+go vet -tags integration ./adt/...
+```
+Expected: clean build. (The tests themselves only run when SAP credentials are configured; without them `eachSystem` calls `t.Skip`.)
+
+- [ ] **Step 3: Add the runtime-exception (throwing) test that resolves the open verification point**
+
+Append to `adt/classrun_integration_test.go`:
+
+```go
+// TestRunClass_ThrowingClass resolves spec open verification point #1: how an
+// uncaught runtime exception in main() is signalled. Two outcomes are valid;
+// the test records which one holds and does NOT hard-fail on either, because
+// the spec commits to updating the doc + assertion once the live behaviour is
+// known. Update this test to a strict assertion after the first green run.
+func TestRunClass_ThrowingClass(t *testing.T) {
+	for _, sys := range eachSystem(t) {
+		sys := sys
+		t.Run(sys.Name, func(t *testing.T) {
+			ctx := context.Background()
+			result, err := sys.Client.RunClass(ctx, classrunThrowFixture)
+			switch {
+			case err != nil:
+				var adtErr *adt.ADTError
+				if errors.As(err, &adtErr) && adtErr.StatusCode == 404 {
+					t.Skipf("throwing fixture %s not available on %s (404)",
+						classrunThrowFixture, sys.Name)
+				}
+				// Outcome (a): non-2xx with the dump/exception text -> ADTError.
+				t.Logf("%s: throwing class surfaced as HTTP error: %v", sys.Name, err)
+			case result != nil:
+				// Outcome (b): 200 with the error text in the console body.
+				t.Logf("%s: throwing class returned 200 with body: %q",
+					sys.Name, result.ConsoleOutput)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 4: Verify the file still builds**
+
+Run: `go build -tags integration ./adt/... && go vet -tags integration ./adt/...`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add adt/classrun_integration_test.go
+git commit -m "test: add multi-system integration tests for RunClass"
+```
+
+- [ ] **Step 6: Open the PR and hand off to the workflow**
+
+Push the branch and open a PR that:
+- Links this plan, the adtler issue (if assigned), and the consumer issue `Hochfrequenz/aibap.mcp#383`.
+- Adds the `needs:integration-test` label (the integration tests need real R/3 + S/4 runs and the fixture classes delivered to `Z_ADT_MCP_TEST` first).
+- Notes the fixture-delivery ordering dependency in the PR body.
+
+The real-SAP integration run (workflow step 4) will exercise `TestRunClass_Integration` and `TestRunClass_ThrowingClass` on both systems, resolve the open verification points, and report per-system PASS/FAIL. After that run, update the spec doc (`docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md`, "Open verification points" section) and tighten `TestRunClass_ThrowingClass` into a strict assertion matching the observed behaviour.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- `RunClass(ctx, className)` + `ClassRunResult` + `ClassRunClient` interface → Task 1, Steps 3-4. ✅
+- `ClassRunClient` embedded in aggregate `Client` → Task 1, Step 4. ✅
+- `Accept: text/plain` hard-coded, no negotiation → Task 1, Step 3 (`contentTypeTextPlain`) + Global Constraints. ✅
+- URI = base + lower-cased name; namespace `//`-encoding via `doMutate` → Task 1, Steps 3, 8-9. ✅
+- Stateless, no lock, 30 s `doMutate`, empty body → Task 1, Step 3 + Step 1 assertions. ✅
+- Body as `string(body)`, UTF-8 survives → Task 1, Steps 6-7. ✅
+- HTTP errors via `checkResponse` → `ADTError` with body preserved → Task 1, Steps 10-11. ✅
+- Runtime-exception open verification point → Task 2, Step 3. ✅
+- Unit tests: success (POST, empty body, CSRF header, text/plain, parsed body), URI, UTF-8, HTTP error → Task 1. ✅
+- Integration via `eachSystem(t)` over R/3 + S/4, namespaced + throwing variants, HFQ availability → Task 2. ✅
+- Fixture-first ordering dependency → Task 2 precondition + Step 6. ✅
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases"/"similar to Task N". Every code step carries full code. The one deferred item — the throwing-class strict assertion — is intentional per the spec's open verification point and is explicitly scheduled in Task 2 Step 6, not a placeholder.
+
+**3. Type consistency:** `ClassRunResult{ClassName, ConsoleOutput}`, `RunClass(ctx, className string) (*ClassRunResult, error)`, and `classrunBase`/`classrunFixture` constants are named identically across all tasks and match the spec's `adt/classrun.go` block.

--- a/docs/superpowers/plans/2026-07-23-classrun-endpoint.md
+++ b/docs/superpowers/plans/2026-07-23-classrun-endpoint.md
@@ -405,15 +405,19 @@ git commit -m "feat: add RunClass client for ADT classrun endpoint"
 - Create: `adt/classrun_integration_test.go`
 
 **Interfaces:**
-- Consumes: `eachSystem(t)` (`integration_helpers_test.go:161`), `adt.Client.RunClass` (from Task 1), `adt.ADTError`. The fixture classes live in `testPackage` (`Z_ADT_MCP_TEST`) but are referenced by name via the `classrunFixture`/`classrunThrowFixture` consts, not through the `testPackage` symbol.
-- Produces: nothing consumed by later tasks. This task also **resolves open verification point #1** (runtime-exception signalling) and **#2** (classrun availability on HFQ/ECC) by observing live behaviour and updating the spec doc.
+- Consumes: `eachSystem(t)` (`integration_helpers_test.go:161`), `adt.Client.RunClass` (from Task 1), `adt.Client.GetObjectInfo` (fixture-existence pre-check), `adt.ADTError`. The fixture classes live in `testPackage` (`Z_ADT_MCP_TEST`) but are referenced by name via the `classrunFixture`/`classrunThrowFixture` consts, not through the `testPackage` symbol.
+- Produces: nothing consumed by later tasks. Confirms live behaviour against the SAP handler; the spec's open verification points #1 and #2 were already resolved by reading `CL_OO_ADT_RES_CLASSRUN` on both HFQ and S4U (see the "Verified against the SAP handler" note below), and this task is the runtime confirmation of that reading.
+
+**Verified against the SAP handler (2026-07-23, HFQ + S4U):** The classrun request is served by `CL_OO_ADT_RES_CLASSRUN`, method `post`. Reading its source on both systems confirmed: POST; response `text/plain` (`if_rest_media_type=>gc_text_plain`); the class name is read as a URI attribute and `TRANSLATE ... TO UPPER CASE`d server-side (so client lower-casing is a convention, not a functional requirement); no request body is read. The handler wraps the `main()` call in a `TRY ... CATCH cx_sy_create_object_error` only, so:
+- **Uncaught runtime exception in `main()`** (e.g. `cx_sy_zerodivide`) → not caught → propagates → the ADT REST framework returns a **non-2xx HTTP error** → `*adt.ADTError`.
+- **"Soft" failures** — missing `S_DEVELOP` authorization, or a class that does not implement the interface / cannot be instantiated (`cx_sy_create_object_error`) — are written into the body and returned as **HTTP 200 with an error string**. A non-existent class therefore comes back as **200-with-text, NOT 404**. A 404 only happens if the classrun endpoint itself is absent — which it is not, on either system.
 
 **Precondition (ordering dependency):** The fixture classes must exist in `Z_ADT_MCP_TEST` before these tests can pass:
-- `ZCL_ADT_MCP_CLASSRUN_TST` — implements `IF_OO_ADT_CLASSRUN`; its `main` writes a known string (`out->write( 'CLASSRUN_OK' ).`).
-- A throwing variant, e.g. `ZCL_ADT_MCP_CLASSRUN_ERR` — its `main` raises an uncaught exception (`RAISE EXCEPTION TYPE cx_sy_zerodivide.` or similar).
+- `ZCL_ADT_MCP_CLASSRUN_TST` — implements `IF_OO_ADT_CLASSRUN`; its `main` writes a known string (`out->write( 'CLASSRUN_OK' ).`). Note: on HFQ the console-out interface differs (`IF_OO_ADT_CLASSRUN_OUT` is absent; the older handler uses `write_text`), so the fixture's `main` body may need a system-appropriate variant — a fixture concern, not a Go-client one.
+- A throwing variant, e.g. `ZCL_ADT_MCP_CLASSRUN_ERR` — its `main` raises an **uncaught** exception (`RAISE EXCEPTION TYPE cx_sy_zerodivide.` or similar). Per the handler analysis above this surfaces as an `*adt.ADTError` (HTTP 5xx), not 200-with-text.
 - (Optional, HFQ-specific) a namespaced variant `/NA2/CL_ADT_MCP_CLASSRUN` if the `/NA2/` namespace is available on the target system; otherwise the namespace encoding is already covered by the Task 1 unit test.
 
-These are delivered via the [Z_ADT_MCP_TEST](https://github.com/Hochfrequenz/Z_ADT_MCP_TEST) repo. If a fixture is missing on a system, the sub-test should `t.Skip` with a clear message rather than fail.
+These are delivered via the [Z_ADT_MCP_TEST](https://github.com/Hochfrequenz/Z_ADT_MCP_TEST) repo. Because a missing fixture returns 200-with-text (not 404), the sub-tests `t.Skip` by **pre-checking class existence with `GetObjectInfo`**, not by catching a 404.
 
 - [ ] **Step 1: Write the happy-path integration test**
 
@@ -426,12 +430,15 @@ package adt_test
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
 	"github.com/Hochfrequenz/adtler/adt"
 )
+
+// NOTE: `errors` is added to this import block in Step 3, when
+// TestRunClass_ThrowingClass first uses errors.As. Adding it now would be an
+// unused-import compile error and break Step 2's clean build.
 
 // classrunFixture is the global class in Z_ADT_MCP_TEST that implements
 // IF_OO_ADT_CLASSRUN and writes classrunFixtureOutput to the console.
@@ -441,23 +448,32 @@ const (
 	classrunThrowFixture  = "ZCL_ADT_MCP_CLASSRUN_ERR"
 )
 
+// classrunClassURI returns the ADT class URI for a classrun fixture name.
+func classrunClassURI(name string) string {
+	return "/sap/bc/adt/oo/classes/" + strings.ToLower(name)
+}
+
 // TestRunClass_Integration runs a real classrun class on every whitelisted
 // system (R/3 and S/4 via eachSystem) and asserts the known console string
-// comes back. This also confirms whether the classrun framework
-// (IF_OO_ADT_CLASSRUN) is available on each system — see spec open
-// verification point #2 (HFQ/ECC not previously verified).
+// comes back. This also exercises the classrun framework on each system —
+// the endpoint handler CL_OO_ADT_RES_CLASSRUN is present on both HFQ/ECC and
+// S4U (spec open verification point #2, resolved).
+//
+// The fixture-existence pre-check uses GetObjectInfo, NOT a 404 from RunClass:
+// the handler returns HTTP 200 with an error string for a missing/invalid
+// class (verified against CL_OO_ADT_RES_CLASSRUN), so a missing fixture would
+// otherwise fail the ConsoleOutput assertion instead of skipping cleanly.
 func TestRunClass_Integration(t *testing.T) {
 	for _, sys := range eachSystem(t) {
 		sys := sys
 		t.Run(sys.Name, func(t *testing.T) {
 			ctx := context.Background()
+			if _, err := sys.Client.GetObjectInfo(ctx, classrunClassURI(classrunFixture)); err != nil {
+				t.Skipf("classrun fixture %s not present on %s (deliver it to Z_ADT_MCP_TEST first): %v",
+					classrunFixture, sys.Name, err)
+			}
 			result, err := sys.Client.RunClass(ctx, classrunFixture)
 			if err != nil {
-				var adtErr *adt.ADTError
-				if errors.As(err, &adtErr) && adtErr.StatusCode == 404 {
-					t.Skipf("classrun fixture %s or endpoint not available on %s (404): %v",
-						classrunFixture, sys.Name, err)
-				}
 				t.Fatalf("RunClass on %s failed: %v", sys.Name, err)
 			}
 			if !strings.Contains(result.ConsoleOutput, classrunFixtureOutput) {
@@ -479,35 +495,48 @@ go vet -tags integration ./adt/...
 ```
 Expected: clean build. (The tests themselves only run when SAP credentials are configured; without them `eachSystem` calls `t.Skip`.)
 
-- [ ] **Step 3: Add the runtime-exception (throwing) test that resolves the open verification point**
+- [ ] **Step 3: Add the runtime-exception (throwing) test**
 
-Append to `adt/classrun_integration_test.go`:
+Add `"errors"` to the import block of `adt/classrun_integration_test.go` now (it was deferred in Step 1 to avoid an unused-import error). The final import block is `context`, `errors`, `strings`, `testing`, plus `adt` — all used. Then append:
 
 ```go
-// TestRunClass_ThrowingClass resolves spec open verification point #1: how an
-// uncaught runtime exception in main() is signalled. Two outcomes are valid;
-// the test records which one holds and does NOT hard-fail on either, because
-// the spec commits to updating the doc + assertion once the live behaviour is
-// known. Update this test to a strict assertion after the first green run.
+// TestRunClass_ThrowingClass confirms how an uncaught runtime exception in
+// main() is signalled — spec open verification point #1. Verified against
+// CL_OO_ADT_RES_CLASSRUN: main() runs inside a TRY that catches only
+// cx_sy_create_object_error, so a genuine uncaught runtime exception (e.g.
+// cx_sy_zerodivide) propagates and the ADT REST framework turns it into a
+// non-2xx HTTP error -> *adt.ADTError. "Soft" failures (missing S_DEVELOP
+// auth, class does not implement the interface) instead come back as HTTP 200
+// with the error text in the body.
+//
+// The test therefore EXPECTS an ADTError for the throwing fixture, and logs
+// the observed status/body so the exact status code can be pinned. If the
+// fixture instead returns 200, that means it failed "softly" rather than
+// throwing — adjust the fixture, not the client.
 func TestRunClass_ThrowingClass(t *testing.T) {
 	for _, sys := range eachSystem(t) {
 		sys := sys
 		t.Run(sys.Name, func(t *testing.T) {
 			ctx := context.Background()
+			if _, err := sys.Client.GetObjectInfo(ctx, classrunClassURI(classrunThrowFixture)); err != nil {
+				t.Skipf("throwing fixture %s not present on %s: %v",
+					classrunThrowFixture, sys.Name, err)
+			}
 			result, err := sys.Client.RunClass(ctx, classrunThrowFixture)
-			switch {
-			case err != nil:
-				var adtErr *adt.ADTError
-				if errors.As(err, &adtErr) && adtErr.StatusCode == 404 {
-					t.Skipf("throwing fixture %s not available on %s (404)",
-						classrunThrowFixture, sys.Name)
-				}
-				// Outcome (a): non-2xx with the dump/exception text -> ADTError.
-				t.Logf("%s: throwing class surfaced as HTTP error: %v", sys.Name, err)
-			case result != nil:
-				// Outcome (b): 200 with the error text in the console body.
-				t.Logf("%s: throwing class returned 200 with body: %q",
+			if err == nil {
+				t.Logf("%s: throwing class returned HTTP 200 (soft failure), body: %q",
 					sys.Name, result.ConsoleOutput)
+				return
+			}
+			var adtErr *adt.ADTError
+			if !errors.As(err, &adtErr) {
+				t.Fatalf("%s: expected *adt.ADTError, got %T: %v", sys.Name, err, err)
+			}
+			t.Logf("%s: throwing class surfaced as ADTError, status %d: %s",
+				sys.Name, adtErr.StatusCode, adtErr.Message)
+			if adtErr.StatusCode < 500 {
+				t.Logf("%s: NOTE status %d is below 5xx — record it and tighten this assertion",
+					sys.Name, adtErr.StatusCode)
 			}
 		})
 	}

--- a/docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md
+++ b/docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md
@@ -1,0 +1,130 @@
+# Design: `RunClass` — ADT Classrun endpoint client
+
+- **Date:** 2026-07-22
+- **Repo:** adtler
+- **Status:** Proposed
+- **Companion spec:** aibap.mcp `run_class` tool — `docs/superpowers/specs/2026-07-22-run-class-tool-design.md` (consumer of this endpoint; that PR is `blocked-by-adtler` until this ships in a tagged release).
+
+## Motivation
+
+ADT exposes a "Run as ABAP Application" capability (Eclipse F9) via the classrun
+endpoint: any global class implementing `IF_OO_ADT_CLASSRUN` can be executed
+server-side, and whatever its `main` method writes to the console handler is
+returned to the client. adtler has no client for this endpoint today.
+
+The immediate downstream driver is a headless lock-cleanup helper (aibap.mcp
+issue #383): the only way to invoke `cl_enq_admin~remove_locks` — or any other
+helper class — without a SAP GUI is to deploy a class and execute it via
+classrun. `RunClass` is the generic primitive that makes that (and other
+diagnostic/helper flows) possible. This spec covers **only** the generic
+endpoint client; no lock-specific logic lives here.
+
+Verified precondition (S4U, 2026-07-22): interface `IF_OO_ADT_CLASSRUN`
+(package `SEO_ADT`, "Implement this interface to execute an ABAP class
+(Classrun)") exists, so the classrun framework is present on the target system.
+
+## Scope
+
+**In scope:** a new `RunClass(ctx, className)` client method that POSTs to the
+classrun endpoint and returns the console output; a `ClassRunResult` type; a
+`ClassRunClient` interface; content-type negotiation via discovery; unit and
+integration tests.
+
+**Out of scope:** any validation of whether the class exists / is active /
+implements the interface (the consumer performs those pre-checks using existing
+adtler reads — see the companion spec); creating or activating classes; any
+lock-specific behaviour.
+
+## The classrun endpoint
+
+```
+POST /sap/bc/adt/oo/classrun/{name}        name = lower-cased class name
+Accept: text/plain                          console output (out->write(...))
+(no request body)
+→ 200 text/plain: the class's console output
+```
+
+Notes / decisions:
+
+- **URI construction:** lower-case the class name and append to
+  `/sap/bc/adt/oo/classrun/`. Mirror the existing URI-escaping helper used for
+  other object paths (see `client.go` namespace/`%2f` handling) so
+  namespaced classes (`/foo/bar`) work.
+- **Content negotiation:** resolve the `Accept`/content type via
+  `NegotiateContentType` / discovery rather than hard-coding, per the repo
+  convention. `text/plain` is the expected default; the discovery document may
+  advertise a versioned type on some systems. Hard-coded `text/plain` remains
+  the fallback when discovery is empty.
+- **Session:** stateless. No lock is acquired — classrun only executes. Any
+  locking/commit the executed class performs is the class's own concern.
+
+## API design
+
+```go
+// adt/classrun.go
+type ClassRunResult struct {
+    ClassName     string `json:"class_name"`
+    ConsoleOutput string `json:"console_output"`
+}
+
+type ClassRunClient interface {
+    RunClass(ctx context.Context, className string) (*ClassRunResult, error)
+}
+
+func (c *httpClient) RunClass(ctx context.Context, className string) (*ClassRunResult, error)
+```
+
+`RunClass` builds the URI, POSTs with the negotiated `Accept`, runs
+`checkResponse`, and on success returns `ClassRunResult{ClassName: className,
+ConsoleOutput: <body>}`. Follows the shape of existing methods in
+`adt/activate.go` (`doMutate` → `checkResponse` → parse body).
+
+## Error handling
+
+- **HTTP errors** (403 auth, 404, 500, …): surface through `checkResponse` →
+  `ADTError`, **preserving the response body text** so the caller sees the SAP
+  message. No special casing beyond the existing error path.
+- **Uncaught runtime exception in `main`** — OPEN VERIFICATION POINT. Two
+  possible behaviours; the integration test decides which holds on the target:
+  - (a) classrun returns a non-2xx status with the dump/exception text → it
+    lands as an `ADTError` (body preserved). No code change needed.
+  - (b) classrun returns `200` with the error text in the body → it is a
+    *successful run with error output*; `RunClassResult.ConsoleOutput` carries
+    the text and it is up to the caller to interpret. No code change needed.
+  Either way `RunClass` itself needs no exception-specific branch; the spec
+  records the expectation and the test pins the actual behaviour.
+
+## Testing
+
+**Unit (`httptest` mock, no build tag):**
+- Successful POST → `ConsoleOutput` parsed from a `200` `text/plain` body.
+- URI construction: lower-cased name, correct `/sap/bc/adt/oo/classrun/` path,
+  namespaced-name escaping.
+- Content negotiation: discovery present (versioned type) vs. empty (falls back
+  to `text/plain`).
+- HTTP error (403 / 404 / 500) → `ADTError` with body text retained.
+
+**Integration (`//go:build integration`, live S4U):**
+- `RunClass` against a real Z classrun class in package `Z_ADT_MCP_TEST`
+  (e.g. `ZCL_ADT_MCP_CLASSRUN_TST`, implements `IF_OO_ADT_CLASSRUN`, writes a
+  known string via `out->write`) → asserts the known string comes back.
+- A throwing variant of the fixture class → **resolves the open verification
+  point** above (records whether the runtime exception arrives as HTTP error or
+  200-with-text; adjust the doc + any test assertion to match).
+- Fixture class added to the [Z_ADT_MCP_TEST](https://github.com/Hochfrequenz/Z_ADT_MCP_TEST)
+  repo so CI and other consumers have it.
+
+## Open verification points
+
+1. Runtime-exception signalling (HTTP error vs. 200-with-text) — see Error
+   handling.
+2. Exact `Accept`/content type the endpoint negotiates on S4U vs. ECC (HFQ) —
+   confirm `text/plain` and whether a versioned type is advertised.
+3. Whether classrun requires any specific session type or extra header on the
+   target systems (expected: plain stateless POST).
+
+## Downstream / linkage
+
+Once released (target tag: next adtler minor), the aibap.mcp `run_class` tool
+consumes `ClassRunClient.RunClass`. The aibap.mcp tool PR references this PR and
+tag and carries the `blocked-by-adtler` label until the bump lands.

--- a/docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md
+++ b/docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-07-22
 - **Repo:** adtler
-- **Status:** Proposed (revised after agent review)
+- **Status:** Proposed (revised after agent review + live handler verification on HFQ and S4U, 2026-07-23)
 - **Companion spec:** aibap.mcp `run_class` tool — `<aibap.mcp>/docs/superpowers/specs/2026-07-22-run-class-tool-design.md` (consumer of this endpoint; that PR is `blocked-by-adtler` until this ships in a tagged release).
 
 ## Motivation
@@ -19,9 +19,14 @@ classrun. `RunClass` is the generic primitive that makes that (and other
 diagnostic/helper flows) possible. This spec covers **only** the generic
 endpoint client; no lock-specific logic lives here.
 
-Verified precondition (S4U, 2026-07-22): interface `IF_OO_ADT_CLASSRUN`
-(package `SEO_ADT`) exists, so the classrun framework is present on that system.
-Its presence on HFQ (ECC/R3) is **not yet verified** — see verification points.
+Verified precondition (2026-07-23, HFQ **and** S4U): the classrun framework is
+present on **both** systems. The request handler `CL_OO_ADT_RES_CLASSRUN`
+(package `SEO_ADT`) and interface `IF_OO_ADT_CLASSRUN` exist on each; its source
+was read on both to confirm the endpoint contract (see "The classrun endpoint"
+and "Error handling"). Note the HFQ (ECC) handler is an older variant:
+`IF_OO_ADT_CLASSRUN_OUT` is absent there and the console-out object uses
+`write_text`, and the ECC handler additionally accepts `PROG`/`DDLS` object
+types — none of which affects the `text/plain` client contract.
 
 ## Scope
 
@@ -52,6 +57,9 @@ Notes / decisions:
   applies `encodeNamespacePath` automatically (it triggers on `//`), so a
   namespaced class built as `/sap/bc/adt/oo/classrun//na2/foo` is encoded to
   `%2fna2%2ffoo` by the client. Just build the raw URI and let `doMutate` handle it.
+  (Verified 2026-07-23: the handler `TRANSLATE`s the class name `TO UPPER CASE`
+  server-side, so lower-casing is a convention/namespace-encoding requirement,
+  not a functional one — both forms resolve to the same class.)
 - **Content type:** hard-code `contentTypeTextPlain` for `Accept`. classrun
   returns plain console text; a versioned content type is not expected, and
   `NegotiateContentType` does an **exact** discovery-key lookup (`discovery.go`),
@@ -103,15 +111,25 @@ ConsoleOutput: string(body)}`. Follows `ActivateObjects` / `GetSource`
   `ADTError`, preserving the response body text so the caller sees the SAP
   message. The existing 4-layer `parseADTError` already handles SAP HTML dump
   pages — no new error class needed.
-- **Uncaught runtime exception in `main`** — OPEN VERIFICATION POINT. Two
-  possible behaviours; the integration test decides which holds:
-  - (a) non-2xx status with the dump/exception text → lands as `ADTError`
-    (body preserved). No code change.
-  - (b) `200` with the error text in the body → a *successful run with error
-    output*; `ClassRunResult.ConsoleOutput` carries the text, caller interprets.
-    No code change.
-  `RunClass` needs no exception-specific branch either way; the test pins the
-  actual behaviour and this doc is updated to match.
+- **Failure signalling — resolved (2026-07-23) by reading `CL_OO_ADT_RES_CLASSRUN`
+  on both systems.** The handler wraps the `main()` call in a `TRY ... CATCH
+  cx_sy_create_object_error` only. This produces a **split** contract:
+  - (a) **Uncaught runtime exception in `main`** (e.g. `cx_sy_zerodivide`) is
+    *not* caught → propagates → the ADT REST framework returns a **non-2xx**
+    HTTP error → lands as `ADTError` (body preserved). No code change.
+  - (b) **"Soft" failures return HTTP `200` with the error text in the body:**
+    missing `S_DEVELOP` authorization, a class that does not implement the
+    interface, or a class that cannot be instantiated (`cx_sy_create_object_error`)
+    are all written to the response body. **A non-existent class is 200-with-text,
+    NOT 404.** `ClassRunResult.ConsoleOutput` carries the text; the caller
+    interprets it.
+  `RunClass` needs no exception-specific branch either way — it returns an
+  `ADTError` for (a) and a `ClassRunResult` for (b). **Consumers (aibap.mcp
+  `run_class`) must not treat a successful `RunClass` return as "the class
+  succeeded": the console output may be an error string** (SAP `OO 755` auth
+  message, `"Error: Class does not implement..."`, etc.). Pre-checking class
+  existence/activeness before calling is the consumer's job (already in the
+  companion spec).
 
 ## Testing
 
@@ -137,11 +155,23 @@ S/4, per the repo convention):**
   (`IF_OO_ADT_CLASSRUN`) exists on HFQ/ECC, not just S4U.
 - Fixture class added to [Z_ADT_MCP_TEST](https://github.com/Hochfrequenz/Z_ADT_MCP_TEST).
 
-## Open verification points
+## Verification points
 
-1. Runtime-exception signalling (HTTP error vs. 200-with-text) — see Error handling.
-2. `IF_OO_ADT_CLASSRUN` / classrun endpoint availability on HFQ (ECC/R3) — only S4U verified so far.
-3. Whether classrun needs any specific session type or extra header (expected: plain stateless POST).
+1. **Resolved (2026-07-23).** Failure signalling is split: uncaught runtime
+   exception → non-2xx (`ADTError`); soft failures (auth, interface not
+   implemented, non-existent class) → HTTP 200 with an error string in the
+   body. See Error handling. Runtime confirmation lands with the integration
+   test (`TestRunClass_ThrowingClass`).
+2. **Resolved (2026-07-23).** The classrun endpoint is available on **both**
+   HFQ (ECC/R3) and S4U — handler `CL_OO_ADT_RES_CLASSRUN` and interface
+   `IF_OO_ADT_CLASSRUN` exist on each. The HFQ handler is an older variant (no
+   `IF_OO_ADT_CLASSRUN_OUT`, uses `write_text`, also serves `PROG`/`DDLS`), but
+   the `text/plain` client contract is identical.
+3. **Resolved (2026-07-23).** Plain stateless POST, no special session type or
+   extra header required. The handler reads only the `classname` URI attribute
+   (uppercased server-side), an optional `profilerId` query param, and two
+   optional `sap-adt-push-*` headers for async console streaming — none needed
+   for the synchronous `RunClass` path.
 
 ## Rollout / linkage
 

--- a/docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md
+++ b/docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md
@@ -2,8 +2,8 @@
 
 - **Date:** 2026-07-22
 - **Repo:** adtler
-- **Status:** Proposed
-- **Companion spec:** aibap.mcp `run_class` tool — `docs/superpowers/specs/2026-07-22-run-class-tool-design.md` (consumer of this endpoint; that PR is `blocked-by-adtler` until this ships in a tagged release).
+- **Status:** Proposed (revised after agent review)
+- **Companion spec:** aibap.mcp `run_class` tool — `<aibap.mcp>/docs/superpowers/specs/2026-07-22-run-class-tool-design.md` (consumer of this endpoint; that PR is `blocked-by-adtler` until this ships in a tagged release).
 
 ## Motivation
 
@@ -20,19 +20,19 @@ diagnostic/helper flows) possible. This spec covers **only** the generic
 endpoint client; no lock-specific logic lives here.
 
 Verified precondition (S4U, 2026-07-22): interface `IF_OO_ADT_CLASSRUN`
-(package `SEO_ADT`, "Implement this interface to execute an ABAP class
-(Classrun)") exists, so the classrun framework is present on the target system.
+(package `SEO_ADT`) exists, so the classrun framework is present on that system.
+Its presence on HFQ (ECC/R3) is **not yet verified** — see verification points.
 
 ## Scope
 
 **In scope:** a new `RunClass(ctx, className)` client method that POSTs to the
 classrun endpoint and returns the console output; a `ClassRunResult` type; a
-`ClassRunClient` interface; content-type negotiation via discovery; unit and
-integration tests.
+`ClassRunClient` interface **embedded into the aggregate `Client` interface**;
+unit and integration tests.
 
 **Out of scope:** any validation of whether the class exists / is active /
-implements the interface (the consumer performs those pre-checks using existing
-adtler reads — see the companion spec); creating or activating classes; any
+implements the interface (the consumer does the class-exists pre-check using
+existing adtler reads — see companion spec); creating or activating classes; any
 lock-specific behaviour.
 
 ## The classrun endpoint
@@ -47,16 +47,27 @@ Accept: text/plain                          console output (out->write(...))
 Notes / decisions:
 
 - **URI construction:** lower-case the class name and append to
-  `/sap/bc/adt/oo/classrun/`. Mirror the existing URI-escaping helper used for
-  other object paths (see `client.go` namespace/`%2f` handling) so
-  namespaced classes (`/foo/bar`) work.
-- **Content negotiation:** resolve the `Accept`/content type via
-  `NegotiateContentType` / discovery rather than hard-coding, per the repo
-  convention. `text/plain` is the expected default; the discovery document may
-  advertise a versioned type on some systems. Hard-coded `text/plain` remains
-  the fallback when discovery is empty.
+  `/sap/bc/adt/oo/classrun/` (mirrors `object.go` `endpoint + "/" +
+  strings.ToLower(name)`). No manual escaping call is needed: `doMutate`
+  applies `encodeNamespacePath` automatically (it triggers on `//`), so a
+  namespaced class built as `/sap/bc/adt/oo/classrun//na2/foo` is encoded to
+  `%2fna2%2ffoo` by the client. Just build the raw URI and let `doMutate` handle it.
+- **Content type:** hard-code `contentTypeTextPlain` for `Accept`. classrun
+  returns plain console text; a versioned content type is not expected, and
+  `NegotiateContentType` does an **exact** discovery-key lookup (`discovery.go`),
+  not the longest-prefix match `sourceContentType` uses — passing the per-object
+  URI would never match the collection-href key and would silently fall back to
+  `text/plain` anyway. Hard-coding is honest and avoids a misleading negotiation
+  call. (If discovery ever advertises a versioned classrun type, revisit.)
 - **Session:** stateless. No lock is acquired — classrun only executes. Any
   locking/commit the executed class performs is the class's own concern.
+- **Timeout:** use the standard `doMutate` (30 s) client. A diagnostic helper
+  could in principle run long, but `doMutateLong` (context-driven) is only
+  warranted if a concrete use case needs it; default to `doMutate` and note the
+  30 s ceiling. Large console outputs are read in full via `io.ReadAll` (same as
+  `GetSource`); no truncation client-side.
+- **Charset:** decode the body as `GetSource` does — `string(body)`, honouring
+  `text/plain; charset=utf-8` — so non-ASCII console output (Umlaute) survives.
 
 ## API design
 
@@ -74,57 +85,69 @@ type ClassRunClient interface {
 func (c *httpClient) RunClass(ctx context.Context, className string) (*ClassRunResult, error)
 ```
 
-`RunClass` builds the URI, POSTs with the negotiated `Accept`, runs
-`checkResponse`, and on success returns `ClassRunResult{ClassName: className,
-ConsoleOutput: <body>}`. Follows the shape of existing methods in
-`adt/activate.go` (`doMutate` → `checkResponse` → parse body).
+**`ClassRunClient` MUST be embedded in the aggregate `Client` interface**
+(`client.go`, alongside `ObjectClient`, `DependencyClient`, …). Every capability
+in adtler is reachable through `Client`; the integration test helper returns
+`adt.Client`, and the aibap.mcp consumer needs `RunClass` on the `adt.Client` it
+receives — without embedding it would only be reachable via a type assertion,
+breaking the established pattern.
+
+`RunClass` builds the URI, POSTs with `Accept: text/plain` and an empty body,
+runs `checkResponse`, and on success returns `ClassRunResult{ClassName: className,
+ConsoleOutput: string(body)}`. Follows `ActivateObjects` / `GetSource`
+(`doMutate` → `checkResponse` → parse body).
 
 ## Error handling
 
 - **HTTP errors** (403 auth, 404, 500, …): surface through `checkResponse` →
-  `ADTError`, **preserving the response body text** so the caller sees the SAP
-  message. No special casing beyond the existing error path.
+  `ADTError`, preserving the response body text so the caller sees the SAP
+  message. The existing 4-layer `parseADTError` already handles SAP HTML dump
+  pages — no new error class needed.
 - **Uncaught runtime exception in `main`** — OPEN VERIFICATION POINT. Two
-  possible behaviours; the integration test decides which holds on the target:
-  - (a) classrun returns a non-2xx status with the dump/exception text → it
-    lands as an `ADTError` (body preserved). No code change needed.
-  - (b) classrun returns `200` with the error text in the body → it is a
-    *successful run with error output*; `RunClassResult.ConsoleOutput` carries
-    the text and it is up to the caller to interpret. No code change needed.
-  Either way `RunClass` itself needs no exception-specific branch; the spec
-  records the expectation and the test pins the actual behaviour.
+  possible behaviours; the integration test decides which holds:
+  - (a) non-2xx status with the dump/exception text → lands as `ADTError`
+    (body preserved). No code change.
+  - (b) `200` with the error text in the body → a *successful run with error
+    output*; `ClassRunResult.ConsoleOutput` carries the text, caller interprets.
+    No code change.
+  `RunClass` needs no exception-specific branch either way; the test pins the
+  actual behaviour and this doc is updated to match.
 
 ## Testing
 
 **Unit (`httptest` mock, no build tag):**
-- Successful POST → `ConsoleOutput` parsed from a `200` `text/plain` body.
-- URI construction: lower-cased name, correct `/sap/bc/adt/oo/classrun/` path,
-  namespaced-name escaping.
-- Content negotiation: discovery present (versioned type) vs. empty (falls back
-  to `text/plain`).
+- Successful run → asserts request method is `POST`, body is empty, the
+  `X-CSRF-Token` header is set, and `ConsoleOutput` is parsed from a `200`
+  `text/plain` body.
+- URI construction: lower-cased name, correct `/sap/bc/adt/oo/classrun/` path.
+- UTF-8 console output (Umlaute) round-trips intact.
 - HTTP error (403 / 404 / 500) → `ADTError` with body text retained.
 
-**Integration (`//go:build integration`, live S4U):**
+**Integration (`//go:build integration`, via `eachSystem(t)` over R/3 **and**
+S/4, per the repo convention):**
 - `RunClass` against a real Z classrun class in package `Z_ADT_MCP_TEST`
   (e.g. `ZCL_ADT_MCP_CLASSRUN_TST`, implements `IF_OO_ADT_CLASSRUN`, writes a
   known string via `out->write`) → asserts the known string comes back.
-- A throwing variant of the fixture class → **resolves the open verification
-  point** above (records whether the runtime exception arrives as HTTP error or
-  200-with-text; adjust the doc + any test assertion to match).
-- Fixture class added to the [Z_ADT_MCP_TEST](https://github.com/Hochfrequenz/Z_ADT_MCP_TEST)
-  repo so CI and other consumers have it.
+- A **namespaced** class variant → exercises the `//`-encoding path against a
+  live system (HFQ `/NA2/` context relevant).
+- A **throwing** variant of the fixture class → **resolves the runtime-exception
+  verification point** (records whether it arrives as HTTP error or 200-with-text;
+  update this doc + any assertion to match).
+- `eachSystem(t)` also confirms whether the classrun framework
+  (`IF_OO_ADT_CLASSRUN`) exists on HFQ/ECC, not just S4U.
+- Fixture class added to [Z_ADT_MCP_TEST](https://github.com/Hochfrequenz/Z_ADT_MCP_TEST).
 
 ## Open verification points
 
-1. Runtime-exception signalling (HTTP error vs. 200-with-text) — see Error
-   handling.
-2. Exact `Accept`/content type the endpoint negotiates on S4U vs. ECC (HFQ) —
-   confirm `text/plain` and whether a versioned type is advertised.
-3. Whether classrun requires any specific session type or extra header on the
-   target systems (expected: plain stateless POST).
+1. Runtime-exception signalling (HTTP error vs. 200-with-text) — see Error handling.
+2. `IF_OO_ADT_CLASSRUN` / classrun endpoint availability on HFQ (ECC/R3) — only S4U verified so far.
+3. Whether classrun needs any specific session type or extra header (expected: plain stateless POST).
 
-## Downstream / linkage
+## Rollout / linkage
 
-Once released (target tag: next adtler minor), the aibap.mcp `run_class` tool
-consumes `ClassRunClient.RunClass`. The aibap.mcp tool PR references this PR and
-tag and carries the `blocked-by-adtler` label until the bump lands.
+- **Fixture first:** `ZCL_ADT_MCP_CLASSRUN_TST` (+ throwing + namespaced
+  variants) must be delivered to `Z_ADT_MCP_TEST` before the integration tests
+  can run — explicit ordering dependency.
+- Release `RunClass` in the next adtler minor tag. The aibap.mcp `run_class` tool
+  then consumes `adt.Client.RunClass`; that PR references this PR + tag and
+  carries `blocked-by-adtler` until the bump lands.


### PR DESCRIPTION
## Summary

Adds the `RunClass` client method for the ADT classrun endpoint
(`POST /sap/bc/adt/oo/classrun/{name}`), which executes any global class
implementing `IF_OO_ADT_CLASSRUN` and returns its console output — the generic
"Run as ABAP Application" primitive, headless. This PR now carries the **design
spec, the implementation plan, and the implementation** (originally opened as a
docs-only spec; implementation added on the same branch).

- Spec: `docs/superpowers/specs/2026-07-22-classrun-endpoint-design.md`
- Plan: `docs/superpowers/plans/2026-07-23-classrun-endpoint.md`

## Why (motivation)

This is the enabling primitive for headless recovery of **frozen enqueue
locks**, a real blocker for `aibap.mcp` (Hochfrequenz/aibap.mcp#383): a write
that fails with 403/423 can leave an enqueue lock held server-side that neither
`unlock_object` nor `force_unlock` can clear (connection-count 0 = orphaned;
only SM12's kernel module `enq_remove_locks` clears it). ADT has no native
endpoint to run the cleanup — `RunClass` is what lets a helper class (e.g.
calling `cl_enq_admin~remove_locks`) execute without a GUI.

## What's implemented

- `RunClass(ctx, className)` → `*ClassRunResult{ClassName, ConsoleOutput}`.
- `ClassRunClient` interface, embedded in the aggregate `Client` interface
  (and thus in `*ClientRegistry`; the `custexport` test double gained a stub).
- `Accept: text/plain` hard-coded; stateless POST with empty body; standard
  30 s `doMutate`; body decoded as `string(body)` so UTF-8 survives; namespace
  slash-encoding handled by the existing `encodeNamespacePath` path.
- Unit tests (httptest): success (POST, empty body, CSRF header, `text/plain`,
  parsed output), URI lower-casing, namespace `%2f` encoding, UTF-8 round-trip,
  HTTP error → `*ADTError`.
- Integration tests (`//go:build integration`, via `eachSystem(t)` over R/3 and
  S/4): real class run + throwing-class variant, with a `GetObjectInfo`
  existence pre-check for clean skips.

## Live handler verification (HFQ + S4U)

The endpoint contract was verified by reading the SAP handler
`CL_OO_ADT_RES_CLASSRUN` on both systems, not left to assumption:

- Endpoint present on **both** HFQ (ECC/R3) and S4U (resolves the spec's open
  verification point on ECC availability). The HFQ handler is an older variant
  (no `IF_OO_ADT_CLASSRUN_OUT`, uses `write_text`, also serves `PROG`/`DDLS`),
  but the `text/plain` client contract is identical.
- Response is `text/plain`, POST, no request body; the class name is uppercased
  server-side (so client lower-casing is a convention, not a requirement).
- **Failure signalling is split:** an uncaught runtime exception in `main()`
  propagates as a non-2xx → `ADTError`; "soft" failures (missing `S_DEVELOP`
  auth, interface not implemented, non-existent class) return **HTTP 200 with an
  error string in the body** — a missing class is 200-with-text, not 404.

## Test plan

- `go test ./...` — passing (4 new unit tests + existing suite).
- Integration tests are `//go:build integration` and require SAP credentials +
  the fixture classes (`ZCL_ADT_MCP_CLASSRUN_TST`, `ZCL_ADT_MCP_CLASSRUN_ERR`)
  delivered to `Z_ADT_MCP_TEST`. Pending the real-SAP run (see below).

## Pre-merge notes

- `needs:integration-test`: awaits the real-SAP run on R/3 + S/4 once the
  fixtures are delivered to `Z_ADT_MCP_TEST`.
- After that run pins the exact status code, `TestRunClass_ThrowingClass` will
  be tightened from a probe (logs the status) to a strict assertion.
- Adding `RunClass` to the exported `Client` interface is a minor-version API
  break for any external implementer of that interface — note in release notes.

## Companion

Consumed by the `aibap.mcp` `run_class` tool (Hochfrequenz/aibap.mcp#440),
which is `blocked-by-adtler` until this ships in a tagged release. Consumer-side
implications of the 200-with-text behaviour were cross-posted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
