### PR TITLE
docs(#58): document UnlockObject no-success-signal caveat on LockClient

### DIFF
--- a/adt/client.go
+++ b/adt/client.go
@@ -41,8 +41,9 @@ type ObjectClient interface {
 
 // LockClient handles object locking.
 //
-// UnlockObject caveat: SAP's UNLOCK endpoint (POST {uri}?_action=UNLOCK)
-// returns HTTP 200 with an empty body regardless of outcome — a real release,
+// UnlockObject caveat: SAP's UNLOCK endpoint
+// (POST {uri}?_action=UNLOCK&lockHandle=<handle>) returns HTTP 200 with an
+// empty body regardless of outcome — a real release,
 // a bogus/mismatched handle, and a double unlock are indistinguishable
 // (verified on ECC and S/4). The server-side dequeue (DEQUEUE_EADT_LOCK) is
 // handle-less and exception-less, so a 2xx from UnlockObject does NOT prove

--- a/adt/client.go
+++ b/adt/client.go
@@ -40,6 +40,18 @@ type ObjectClient interface {
 }
 
 // LockClient handles object locking.
+//
+// UnlockObject caveat: SAP's UNLOCK endpoint (POST {uri}?_action=UNLOCK)
+// returns HTTP 200 with an empty body regardless of outcome — a real release,
+// a bogus/mismatched handle, and a double unlock are indistinguishable
+// (verified on ECC and S/4). The server-side dequeue (DEQUEUE_EADT_LOCK) is
+// handle-less and exception-less, so a 2xx from UnlockObject does NOT prove
+// the enqueue was released. There is also no ADT endpoint to read enqueue
+// state, so a release cannot be verified over REST. Secondary auto-locks on
+// coupled objects (e.g. a RAP BDEF's implementation class) are not reachable
+// by handle at all. The only reliable recovery is dropping the stateful
+// session (Logout), which releases every enqueue held under it.
+// See mcp-server-abap#383 and #58.
 type LockClient interface {
 	LockObject(ctx context.Context, objectURI string) (string, error)
 	UnlockObject(ctx context.Context, objectURI, lockHandle string) error


### PR DESCRIPTION
## Summary

Lands **Ask 3** from #58 — a documentation caveat on the `LockClient` interface capturing what live probing on both ECC and S/4 established about SAP's ADT UNLOCK behavior.

Ask 1 (session drop / `Logout`) already shipped in v0.3.7 and is the recovery path behind `force_unlock` downstream. Ask 2 (parse a diagnostic out of the UNLOCK response) was **ruled out as not implementable** — the server-side dequeue (`DEQUEUE_EADT_LOCK`) is handle-less and exception-less, and UNLOCK returns an empty `200` for a real release, a bogus handle, a mismatched URI, and a double unlock alike (verified on both systems). That leaves this doc comment as the one remaining actionable item.

The comment records:
- UNLOCK returns 2xx regardless of outcome — no success signal.
- There is no ADT endpoint to read live enqueue state, so a release cannot be verified over REST.
- Secondary auto-locks on coupled objects (e.g. a RAP BDEF's implementation class) are not reachable by the primary handle.
- The only reliable recovery is dropping the stateful session (`Logout`).

## Test plan

Doc-only change (interface comment). No behavior changes, so no test is added — the documented behavior was already live-verified on ECC and S/4 (evidence recorded on #58) and adtler's integration suite already exercises lock/unlock. `go vet ./adt/` and `gofmt` clean.

Closes #58