### PR TITLE
feat: classify CTS 'locked in request <TR>' as ErrorObjectLockedInTransport

### DIFF
--- a/adt/errorkind.go
+++ b/adt/errorkind.go
@@ -34,6 +34,12 @@ const (
 	ErrorForbidden                   // authorization error
 	ErrorBadRequest                  // the request was malformed
 	ErrorServerError                 // SAP server error (HTTP 500)
+	// ErrorObjectLockedInTransport is a refinement of ErrorLockConflict: the
+	// object is registered in another open CTS request (a "locked in request
+	// <TR>" 409), a different lock domain from the runtime ENQUEUE. The blocking
+	// request is recoverable via ADTError.LockingTransport(); retargeting the
+	// write at it typically succeeds. See mcp-server-abap#442.
+	ErrorObjectLockedInTransport
 )
 
 // String returns a stable, lowercase identifier for the kind (handy for logs
@@ -68,6 +74,8 @@ func (k ErrorKind) String() string {
 		return "bad_request"
 	case ErrorServerError:
 		return "server_error"
+	case ErrorObjectLockedInTransport:
+		return "object_locked_in_transport"
 	default:
 		return "unknown"
 	}
@@ -88,9 +96,24 @@ func ClassifyError(err error) ErrorKind {
 		return ErrorUnknown
 	}
 	if k := classifyByExceptionType(adtErr.Type); k != ErrorUnknown {
+		return refineLockConflict(adtErr, k)
+	}
+	return refineLockConflict(adtErr, classifyByStatusCode(adtErr.StatusCode))
+}
+
+// refineLockConflict promotes a generic ErrorLockConflict to
+// ErrorObjectLockedInTransport when the message names a CTS request — the
+// object is registered in another open request (a different lock domain from
+// the runtime ENQUEUE), which the caller can recover from by retargeting the
+// write at that request. Any other kind is returned unchanged.
+func refineLockConflict(adtErr *ADTError, k ErrorKind) ErrorKind {
+	if k != ErrorLockConflict {
 		return k
 	}
-	return classifyByStatusCode(adtErr.StatusCode)
+	if _, ok := adtErr.LockingTransport(); ok {
+		return ErrorObjectLockedInTransport
+	}
+	return k
 }
 
 // classifyByExceptionType maps a SAP <exc:exception> Type id to a kind, or

--- a/adt/errorkind.go
+++ b/adt/errorkind.go
@@ -14,6 +14,13 @@ import "errors"
 // generic creation failure, or a "transport required" hidden inside a 400 —
 // are reported as their broad kind (ErrorCreationFailed, ErrorBadRequest);
 // callers wanting finer detail inspect the message themselves.
+//
+// One deliberate exception: a lock conflict is promoted to
+// ErrorObjectLockedInTransport when the message carries a CTS request ID. SAP
+// does not expose the blocking request in any structured field, only in the
+// localised message text, so this is the one place classification inspects the
+// message — and it keys on the language-independent request-ID format, not on
+// translated words. See refineLockConflict and ADTError.LockingTransport.
 type ErrorKind int
 
 const (

--- a/adt/errorkind_test.go
+++ b/adt/errorkind_test.go
@@ -109,21 +109,22 @@ func TestClassifyError_WrappedADTError(t *testing.T) {
 
 func TestErrorKind_String(t *testing.T) {
 	cases := map[adt.ErrorKind]string{
-		adt.ErrorUnknown:           "unknown",
-		adt.ErrorAlreadyExists:     "already_exists",
-		adt.ErrorLocked:            "locked",
-		adt.ErrorLockConflict:      "lock_conflict",
-		adt.ErrorInvalidLockHandle: "invalid_lock_handle",
-		adt.ErrorEtagMismatch:      "etag_mismatch",
-		adt.ErrorNotAcceptable:     "not_acceptable",
-		adt.ErrorUnsupportedMedia:  "unsupported_media",
-		adt.ErrorUnprocessable:     "unprocessable",
-		adt.ErrorMethodNotAllowed:  "method_not_allowed",
-		adt.ErrorCreationFailed:    "creation_failed",
-		adt.ErrorNotFound:          "not_found",
-		adt.ErrorForbidden:         "forbidden",
-		adt.ErrorBadRequest:        "bad_request",
-		adt.ErrorServerError:       "server_error",
+		adt.ErrorUnknown:                 "unknown",
+		adt.ErrorAlreadyExists:           "already_exists",
+		adt.ErrorLocked:                  "locked",
+		adt.ErrorLockConflict:            "lock_conflict",
+		adt.ErrorInvalidLockHandle:       "invalid_lock_handle",
+		adt.ErrorEtagMismatch:            "etag_mismatch",
+		adt.ErrorNotAcceptable:           "not_acceptable",
+		adt.ErrorUnsupportedMedia:        "unsupported_media",
+		adt.ErrorUnprocessable:           "unprocessable",
+		adt.ErrorMethodNotAllowed:        "method_not_allowed",
+		adt.ErrorCreationFailed:          "creation_failed",
+		adt.ErrorNotFound:                "not_found",
+		adt.ErrorForbidden:               "forbidden",
+		adt.ErrorBadRequest:              "bad_request",
+		adt.ErrorServerError:             "server_error",
+		adt.ErrorObjectLockedInTransport: "object_locked_in_transport",
 	}
 	// Guard against an unhandled kind silently returning "unknown": a bogus
 	// value must map to "unknown", but every named kind above must not.

--- a/adt/errorkind_transport_test.go
+++ b/adt/errorkind_transport_test.go
@@ -1,0 +1,113 @@
+package adt_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Hochfrequenz/adtler/adt"
+)
+
+// The two messages below are captured verbatim from live S/4 (HF S/4 Mandant
+// 100) on mcp-server-abap#442 — a CTS "object is registered in another open
+// request" conflict (LIMU/CINC sub-include and R3TR/DDLS), distinct from the
+// runtime ENQUEUE. Both arrive as HTTP 409 / ExceptionResourceLockConflict and
+// name the blocking request; retargeting the write at that request succeeds.
+const (
+	lockedInTransportDDLS = "Object R3TR DDLS /HFQ/DD_ADRESSE is already locked in request S4UK901974 of user BECKT"
+	lockedInTransportCINC = "Object LIMU CINC /HFQ/BP_DD_ADRESSE============CCIMP is already locked in request S4UK901974 of user BECKT"
+	// A German-locale rendering of the same message. The extractor keys on the
+	// request-ID format, not the surrounding words, so localisation must not
+	// break it.
+	lockedInTransportDE = "Objekt R3TR DDLS /HFQ/DD_ADRESSE ist bereits in Auftrag S4UK901974 von Benutzer BECKT gesperrt"
+	// trFixture is the request ID named in each captured message above.
+	trFixture = "S4UK901974"
+)
+
+func TestClassifyError_ObjectLockedInTransport(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     *adt.ADTError
+		wantTR  string
+		wantKnd adt.ErrorKind
+	}{
+		{
+			name:    "typed_409_DDLS",
+			err:     &adt.ADTError{StatusCode: 409, Type: adt.ExceptionTypeResourceLockConflict, Message: lockedInTransportDDLS},
+			wantTR:  trFixture,
+			wantKnd: adt.ErrorObjectLockedInTransport,
+		},
+		{
+			name:    "typed_409_CINC",
+			err:     &adt.ADTError{StatusCode: 409, Type: adt.ExceptionTypeResourceLockConflict, Message: lockedInTransportCINC},
+			wantTR:  trFixture,
+			wantKnd: adt.ErrorObjectLockedInTransport,
+		},
+		{
+			name:    "typeless_409_falls_back_to_status",
+			err:     &adt.ADTError{StatusCode: 409, Message: lockedInTransportDDLS},
+			wantTR:  trFixture,
+			wantKnd: adt.ErrorObjectLockedInTransport,
+		},
+		{
+			name:    "german_locale",
+			err:     &adt.ADTError{StatusCode: 409, Type: adt.ExceptionTypeResourceLockConflict, Message: lockedInTransportDE},
+			wantTR:  trFixture,
+			wantKnd: adt.ErrorObjectLockedInTransport,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := adt.ClassifyError(tc.err); got != tc.wantKnd {
+				t.Errorf("ClassifyError = %v, want %v", got, tc.wantKnd)
+			}
+			tr, ok := tc.err.LockingTransport()
+			if !ok || tr != tc.wantTR {
+				t.Errorf("LockingTransport() = (%q, %v), want (%q, true)", tr, ok, tc.wantTR)
+			}
+		})
+	}
+}
+
+func TestClassifyError_LockConflictWithoutTransportStaysLockConflict(t *testing.T) {
+	// A lock conflict whose message names no CTS request must remain the generic
+	// ErrorLockConflict — the refinement only fires when a request ID is present.
+	cases := []*adt.ADTError{
+		{StatusCode: 409, Type: adt.ExceptionTypeResourceLockConflict, Message: "save conflict — a different enqueue is held"},
+		{StatusCode: 409, Message: "conflict"},
+	}
+	for i, err := range cases {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			if got := adt.ClassifyError(err); got != adt.ErrorLockConflict {
+				t.Errorf("ClassifyError = %v, want ErrorLockConflict", got)
+			}
+			if tr, ok := err.LockingTransport(); ok {
+				t.Errorf("LockingTransport() = (%q, true), want (\"\", false)", tr)
+			}
+		})
+	}
+}
+
+func TestADTError_LockingTransport(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		wantTR  string
+		wantOK  bool
+	}{
+		{"ddls_english", lockedInTransportDDLS, trFixture, true},
+		{"cinc_english", lockedInTransportCINC, trFixture, true},
+		{"german", lockedInTransportDE, trFixture, true},
+		{"no_request_id", "Object is already locked by another user", "", false},
+		{"object_name_not_matched", "Object R3TR DDLS /HFQ/DD_ADRESSE locked", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &adt.ADTError{StatusCode: 409, Message: tc.message}
+			tr, ok := err.LockingTransport()
+			if ok != tc.wantOK || tr != tc.wantTR {
+				t.Errorf("LockingTransport(%q) = (%q, %v), want (%q, %v)", tc.message, tr, ok, tc.wantTR, tc.wantOK)
+			}
+		})
+	}
+}

--- a/adt/errorkind_transport_test.go
+++ b/adt/errorkind_transport_test.go
@@ -100,6 +100,15 @@ func TestADTError_LockingTransport(t *testing.T) {
 		{"no_request_id", "Object is already locked by another user", "", false},
 		{"object_name_not_matched", "Object R3TR DDLS /HFQ/DD_ADRESSE locked", "", false},
 		{"empty", "", "", false},
+		// Ordering hazard: the object name precedes the request in the message.
+		// If the name itself matches the <SID>K<6digit> shape, the FIRST match
+		// would be the name — the request ID is always LAST, so last-match wins.
+		{"object_name_matches_pattern", "Object R3TR PROG ABCK123456 is already locked in request S4UK901974 of user X", trFixture, true},
+		// Task + request both present (both share the <SID>K###### format); the
+		// request is named last.
+		{"task_and_request", "locked in task S4UK901975 request S4UK901974 of user X", trFixture, true},
+		{"lowercase_not_matched", "already locked in request s4uk901974", "", false},
+		{"non_K_category_not_matched", "already locked in request ABCT123456", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/adt/types.go
+++ b/adt/types.go
@@ -3,6 +3,7 @@ package adt
 import (
 	"errors"
 	"fmt"
+	"regexp"
 )
 
 // Common constants used across ADT operations.
@@ -186,6 +187,27 @@ func (e *ADTError) Error() string {
 		return fmt.Sprintf("SAP ADT error %d (%s): %s", e.StatusCode, e.Type, e.Message)
 	}
 	return fmt.Sprintf("SAP ADT error %d: %s", e.StatusCode, e.Message)
+}
+
+// ctsRequestRe matches a CTS transport request ID (e.g. "S4UK901974"):
+// a 3-character system ID, the request-category letter 'K', then six digits.
+// This is a language-independent format, so it survives message localisation —
+// SAP's "locked in request <TR>" text is translated but the ID is not.
+var ctsRequestRe = regexp.MustCompile(`\b[A-Z][A-Z0-9]{2}K[0-9]{6}\b`)
+
+// LockingTransport returns the CTS transport request that a "locked in request
+// <TR>" conflict names, if the message contains one. It is meaningful for a
+// lock-conflict error (HTTP 409 / ExceptionResourceLockConflict) where the
+// object is registered in another open request — a lock domain distinct from
+// the runtime ENQUEUE; retargeting the write at the returned request typically
+// clears the conflict. The extraction keys on the request-ID format, not the
+// surrounding words, so it is robust to message localisation. Returns ("",
+// false) when no request ID is present. See mcp-server-abap#442.
+func (e *ADTError) LockingTransport() (string, bool) {
+	if tr := ctsRequestRe.FindString(e.Message); tr != "" {
+		return tr, true
+	}
+	return "", false
 }
 
 // isInvalidLockHandle returns true if the error is a 423

--- a/adt/types.go
+++ b/adt/types.go
@@ -200,12 +200,24 @@ var ctsRequestRe = regexp.MustCompile(`\b[A-Z][A-Z0-9]{2}K[0-9]{6}\b`)
 // lock-conflict error (HTTP 409 / ExceptionResourceLockConflict) where the
 // object is registered in another open request — a lock domain distinct from
 // the runtime ENQUEUE; retargeting the write at the returned request typically
-// clears the conflict. The extraction keys on the request-ID format, not the
-// surrounding words, so it is robust to message localisation. Returns ("",
-// false) when no request ID is present. See mcp-server-abap#442.
+// clears the conflict. Returns ("", false) when no request ID is present.
+// See mcp-server-abap#442.
+//
+// Yes, scraping a transport ID out of a localised, human-readable error string
+// with a regex is ugly and brittle — but SAP gives us no choice: the 409
+// carries the blocking request only inside the free-text <message>, with no
+// structured field (no <exc:properties> entry, no header) exposing it. So we
+// make the parse as robust as it can be: we key on the request-ID *format*
+// rather than the surrounding words (survives translation), and we take the
+// LAST match. The message orders the object name before the request
+// ("Object <PGMID> <TYPE> <NAME> ... locked in request <TR> ..."), so if the
+// locked object's own name happens to match the <SID>K<6-digit> shape, the
+// first match would be the object name; the request ID is always the last CTS
+// ID in the string (English "... request <TR> of user X" and German
+// "... in Auftrag <TR> von Benutzer X gesperrt" both put it last).
 func (e *ADTError) LockingTransport() (string, bool) {
-	if tr := ctsRequestRe.FindString(e.Message); tr != "" {
-		return tr, true
+	if m := ctsRequestRe.FindAllString(e.Message, -1); len(m) > 0 {
+		return m[len(m)-1], true
 	}
 	return "", false
 }


### PR DESCRIPTION
## Summary

Enables an actionable recovery hint for the CTS-409 conflict tracked in mcp-server-abap#442.

A source write to an object that is registered in **another open CTS request** fails with `409 ExceptionResourceLockConflict` and a message that names the blocking request:

```
Object R3TR DDLS /HFQ/DD_ADRESSE is already locked in request S4UK901974 of user BECKT
Object LIMU CINC /HFQ/BP_DD_ADRESSE============CCIMP is already locked in request S4UK901974 of user BECKT
```

This is a **distinct lock domain** from the runtime ENQUEUE (SM12) — it is a CTS object-directory registration, not cleared by `force_unlock`/SM12/transport-delete. The pragmatic recovery, verified live on mcp-server-abap#442, is to **retarget the write at the named request**. But callers previously saw only the generic `ErrorLockConflict` with no way to recover the request ID.

## Change

- New `ErrorKind`: **`ErrorObjectLockedInTransport`** — a refinement of `ErrorLockConflict`. Appended to the const block (no renumbering of existing kinds).
- New method **`(*ADTError).LockingTransport() (string, bool)`** — extracts the CTS request ID by its **language-independent format** (`<SID>K<6 digits>`, e.g. `S4UK901974`) rather than the surrounding English words, so it survives message localisation.
- `ClassifyError` promotes a lock conflict to the new kind **only when a request ID is present**; a lock conflict naming none stays `ErrorLockConflict`.

## Test plan

Unit tests (`adt/errorkind_transport_test.go`) cover:
- Both **verbatim** messages captured live on S/4 (HF S/4 Mandant 100) in mcp-server-abap#442 — DDLS/R3TR and CINC/LIMU — classified via both the typed exception and the bare-409 status fallback.
- A **German-locale** rendering, proving the format-keyed extraction is locale-robust.
- Negative cases: a lock conflict with no request ID stays `ErrorLockConflict`; an object name containing `R3TR DDLS` but no request ID does not false-match; empty message.
- `ErrorKind.String()` guard extended for the new kind.

`go test ./...`, `go vet ./...`, `gofmt`, and `golangci-lint v2.11.4 --enable dupl,goconst,gocyclo` all clean locally.

The **live** end-to-end reproducer/guard (provoke the 409 through the MCP tools, assert the hint + that retargeting the write succeeds) lives downstream in mcp-server-abap, gated behind the `transport` build tag — provoking the conflict requires an object held in an open request, which is stateful and best exercised at the tool layer with proper fixtures rather than manufactured in adtler CI (which would risk the dangling-registration state #442 itself warns about). The message format here is not guessed: it is captured verbatim from the live system.

Refs mcp-server-abap#442