### PR TITLE
fix(#69): search_replace tolerates CRLF sources and errors on no-match

### DIFF
--- a/adt/patch.go
+++ b/adt/patch.go
@@ -133,9 +133,19 @@ func applySearchReplace(src string, op PatchOp) (string, error) {
 	if search == "" {
 		return "", fmt.Errorf("search_replace: empty search string")
 	}
-	if strings.Contains(src, "\r\n") && strings.Contains(search, "\n") && !strings.Contains(search, "\r\n") {
-		search = strings.ReplaceAll(search, "\n", "\r\n")
-		replace = strings.ReplaceAll(replace, "\n", "\r\n")
+	// When the source uses CRLF, align both the search and the replacement to
+	// CRLF so the match succeeds and inserted text keeps the source's
+	// line-ending style. toCRLF normalises first, so it is idempotent and never
+	// turns an existing \r\n into \r\r\n regardless of what mix the caller sent.
+	//
+	// Known limitation: a preceding line-op (insert/replace) splices its content
+	// with bare-LF boundaries (joinLines uses \n), so in an otherwise-CRLF file a
+	// search_replace whose search spans a just-inserted boundary will not match
+	// and returns the not-found error below rather than silently no-op'ing —
+	// split such edits into separate calls or use line-ops throughout.
+	if strings.Contains(src, "\r\n") {
+		search = toCRLF(search)
+		replace = toCRLF(replace)
 	}
 	if !strings.Contains(src, search) {
 		return "", fmt.Errorf("search_replace: search string not found in source (check that the text, whitespace and line endings match exactly)")
@@ -144,6 +154,13 @@ func applySearchReplace(src string, op PatchOp) (string, error) {
 		return strings.ReplaceAll(src, search, replace), nil
 	}
 	return strings.Replace(src, search, replace, 1), nil
+}
+
+// toCRLF rewrites all line endings in s to CRLF. It normalises any existing
+// CRLF back to LF first so the expansion is idempotent (no \r\r\n), and a lone
+// \r or newline-free string is left untouched.
+func toCRLF(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\n", "\r\n")
 }
 
 func opStartLine(op PatchOp) int {

--- a/adt/patch.go
+++ b/adt/patch.go
@@ -126,8 +126,10 @@ func ApplyPatchOps(source string, ops []PatchOp) (string, error) {
 // text keeps the source's line-ending style.
 //
 // It returns an error when the search string is empty or is not present in
-// src, so a search_replace can never silently succeed while changing nothing
-// (the previous behaviour, which still issued a fresh ETag and misled callers).
+// src, so a search_replace can never silently no-op on a zero match — the
+// previous behaviour, which still issued a fresh ETag and misled callers. (A
+// search that is found but whose replacement is identical still succeeds with
+// unchanged output; only the zero-match case is guarded.)
 func applySearchReplace(src string, op PatchOp) (string, error) {
 	if op.Search == "" {
 		return "", fmt.Errorf("search_replace: empty search string")

--- a/adt/patch.go
+++ b/adt/patch.go
@@ -106,14 +106,44 @@ func ApplyPatchOps(source string, ops []PatchOp) (string, error) {
 
 	// Apply search_replace ops in order.
 	for _, op := range srOps {
-		if op.All {
-			result = strings.ReplaceAll(result, op.Search, op.Replace)
-		} else {
-			result = strings.Replace(result, op.Search, op.Replace, 1)
+		var err error
+		result, err = applySearchReplace(result, op)
+		if err != nil {
+			return "", err
 		}
 	}
 
 	return result, nil
+}
+
+// applySearchReplace performs one search_replace op against src.
+//
+// It tolerates a CRLF/LF line-ending mismatch — a common cause of silent
+// no-ops (adtler#69): SAP source is frequently stored with CRLF, but callers
+// naturally write bare-LF search strings, and an LF search never matches a
+// CRLF source. When src uses CRLF and the search uses bare LF, the search and
+// the replacement are realigned to CRLF so the match succeeds and inserted
+// text keeps the source's line-ending style.
+//
+// It returns an error when the search string is empty or is not present in
+// src, so a search_replace can never silently succeed while changing nothing
+// (the previous behaviour, which still issued a fresh ETag and misled callers).
+func applySearchReplace(src string, op PatchOp) (string, error) {
+	search, replace := op.Search, op.Replace
+	if search == "" {
+		return "", fmt.Errorf("search_replace: empty search string")
+	}
+	if strings.Contains(src, "\r\n") && strings.Contains(search, "\n") && !strings.Contains(search, "\r\n") {
+		search = strings.ReplaceAll(search, "\n", "\r\n")
+		replace = strings.ReplaceAll(replace, "\n", "\r\n")
+	}
+	if !strings.Contains(src, search) {
+		return "", fmt.Errorf("search_replace: search string not found in source (check that the text, whitespace and line endings match exactly)")
+	}
+	if op.All {
+		return strings.ReplaceAll(src, search, replace), nil
+	}
+	return strings.Replace(src, search, replace, 1), nil
 }
 
 func opStartLine(op PatchOp) int {

--- a/adt/patch.go
+++ b/adt/patch.go
@@ -129,26 +129,26 @@ func ApplyPatchOps(source string, ops []PatchOp) (string, error) {
 // src, so a search_replace can never silently succeed while changing nothing
 // (the previous behaviour, which still issued a fresh ETag and misled callers).
 func applySearchReplace(src string, op PatchOp) (string, error) {
-	search, replace := op.Search, op.Replace
-	if search == "" {
+	if op.Search == "" {
 		return "", fmt.Errorf("search_replace: empty search string")
 	}
-	// When the source uses CRLF, align both the search and the replacement to
-	// CRLF so the match succeeds and inserted text keeps the source's
-	// line-ending style. toCRLF normalises first, so it is idempotent and never
-	// turns an existing \r\n into \r\r\n regardless of what mix the caller sent.
+	search, replace := op.Search, op.Replace
+	// Try the caller's search verbatim first. This matches a pure-LF source and
+	// also any bare-LF region within an otherwise-CRLF source — e.g. content a
+	// preceding line-op spliced in (joinLines uses \n) — so those keep working.
 	//
-	// Known limitation: a preceding line-op (insert/replace) splices its content
-	// with bare-LF boundaries (joinLines uses \n), so in an otherwise-CRLF file a
-	// search_replace whose search spans a just-inserted boundary will not match
-	// and returns the not-found error below rather than silently no-op'ing —
-	// split such edits into separate calls or use line-ops throughout.
-	if strings.Contains(src, "\r\n") {
-		search = toCRLF(search)
-		replace = toCRLF(replace)
-	}
+	// Only if that fails do we realign to CRLF and retry: SAP source is
+	// frequently stored with CRLF while callers naturally write bare-LF search
+	// strings, and an LF search never matches a CRLF source. When we match via
+	// the realigned search we also realign the replacement, so inserted text
+	// keeps the source's CRLF style. toCRLF normalises first, so it is
+	// idempotent and never turns an existing \r\n into \r\r\n.
 	if !strings.Contains(src, search) {
-		return "", fmt.Errorf("search_replace: search string not found in source (check that the text, whitespace and line endings match exactly)")
+		crlfSearch := toCRLF(search)
+		if crlfSearch == search || !strings.Contains(src, crlfSearch) {
+			return "", fmt.Errorf("search_replace: search string not found in source (check that the text, whitespace and line endings match exactly)")
+		}
+		search, replace = crlfSearch, toCRLF(replace)
 	}
 	if op.All {
 		return strings.ReplaceAll(src, search, replace), nil

--- a/adt/patch_test.go
+++ b/adt/patch_test.go
@@ -99,6 +99,71 @@ func TestApplyOpsSearchReplaceAll(t *testing.T) {
 	}
 }
 
+// adtler#69: a multi-line LF search must match a CRLF source (SAP stores CRLF),
+// and the replacement must be written back with CRLF so line endings stay
+// consistent. Previously this silently no-op'd while issuing a fresh ETag.
+func TestApplyOpsSearchReplace_CRLFSourceLFSearch(t *testing.T) {
+	source := "REPORT ZTEST.\r\nDATA: lv_x TYPE i.\r\nWRITE lv_x."
+	ops := []adt.PatchOp{
+		// search/replace use bare LF, as a caller would naturally write them.
+		{Type: "search_replace", Search: "DATA: lv_x TYPE i.\nWRITE lv_x.", Replace: "DATA: lv_y TYPE string.\nWRITE lv_y."},
+	}
+	got, err := adt.ApplyPatchOps(source, ops)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "REPORT ZTEST.\r\nDATA: lv_y TYPE string.\r\nWRITE lv_y."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "\n") && !strings.Contains(got, "\r\n") {
+		t.Errorf("result lost CRLF line endings: %q", got)
+	}
+}
+
+// A single-line (newline-free) search must still match a CRLF source unchanged.
+func TestApplyOpsSearchReplace_CRLFSourceSingleLineSearch(t *testing.T) {
+	source := "REPORT ZTEST.\r\nDATA: lv_x TYPE i."
+	ops := []adt.PatchOp{
+		{Type: "search_replace", Search: "ZTEST", Replace: "ZNEW"},
+	}
+	got, err := adt.ApplyPatchOps(source, ops)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "REPORT ZNEW.\r\nDATA: lv_x TYPE i."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// adtler#69: a search string that is genuinely absent must ERROR, not silently
+// succeed with an unchanged source.
+func TestApplyOpsSearchReplace_NotFoundErrors(t *testing.T) {
+	source := "REPORT ZTEST.\nDATA: lv_x TYPE i."
+	ops := []adt.PatchOp{
+		{Type: "search_replace", Search: "DOES_NOT_EXIST", Replace: "x"},
+	}
+	got, err := adt.ApplyPatchOps(source, ops)
+	if err == nil {
+		t.Fatalf("expected error for a search string not present, got success with %q", got)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should explain the search was not found, got: %v", err)
+	}
+}
+
+// An empty search string is meaningless and must error rather than prepend the
+// replacement at offset 0.
+func TestApplyOpsSearchReplace_EmptySearchErrors(t *testing.T) {
+	_, err := adt.ApplyPatchOps("REPORT ZTEST.", []adt.PatchOp{
+		{Type: "search_replace", Search: "", Replace: "x"},
+	})
+	if err == nil {
+		t.Fatal("expected error for an empty search string")
+	}
+}
+
 func TestApplyOpsMultiple(t *testing.T) {
 	// Two inserts: ops should be sorted descending by after_line so bottom-up application works.
 	source := "line1\nline2\nline3"

--- a/adt/patch_test.go
+++ b/adt/patch_test.go
@@ -216,19 +216,23 @@ func TestApplyOpsSearchReplace_MultipleOps(t *testing.T) {
 	}
 }
 
-// Known limitation (documented in applySearchReplace): a line-op splices content
-// with a bare-LF boundary, so in a CRLF source a following search_replace that
-// spans that boundary is realigned to CRLF and does not match — it errors
-// loudly rather than silently no-op'ing. This test pins that documented
-// behavior so a future change to it is deliberate.
-func TestApplyOpsSearchReplace_SpanningInsertedBoundaryErrors(t *testing.T) {
+// A search_replace spanning a bare-LF boundary left by a preceding line-op in
+// an otherwise-CRLF source must still match: applySearchReplace tries the
+// verbatim (LF) search before falling back to CRLF realignment, so the
+// bare-LF region matches directly. (Regression guard: an earlier revision
+// realigned unconditionally and spuriously errored here.)
+func TestApplyOpsSearchReplace_SpanningInsertedBoundaryMatches(t *testing.T) {
 	source := "a\r\nb"
-	_, err := adt.ApplyPatchOps(source, []adt.PatchOp{
+	got, err := adt.ApplyPatchOps(source, []adt.PatchOp{
 		{Type: "insert", AfterLine: 1, Content: "NEW"},                // -> "a\r\nNEW\nb"
-		{Type: "search_replace", Search: "NEW\nb", Replace: "NEW\nB"}, // realigned to "NEW\r\nb", not present
+		{Type: "search_replace", Search: "NEW\nb", Replace: "NEW\nB"}, // matches the bare-LF boundary verbatim
 	})
-	if err == nil {
-		t.Fatal("expected not-found error for a search spanning the bare-LF inserted boundary in a CRLF source")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "a\r\nNEW\nB"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 

--- a/adt/patch_test.go
+++ b/adt/patch_test.go
@@ -116,8 +116,10 @@ func TestApplyOpsSearchReplace_CRLFSourceLFSearch(t *testing.T) {
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
-	if strings.Contains(got, "\n") && !strings.Contains(got, "\r\n") {
-		t.Errorf("result lost CRLF line endings: %q", got)
+	// No bare LF may remain: strip every CRLF, then any leftover "\n" is a
+	// lone LF that escaped realignment (catches a mixed CRLF+LF result too).
+	if strings.Contains(strings.ReplaceAll(got, "\r\n", ""), "\n") {
+		t.Errorf("result has a bare LF (not fully CRLF): %q", got)
 	}
 }
 

--- a/adt/patch_test.go
+++ b/adt/patch_test.go
@@ -164,6 +164,74 @@ func TestApplyOpsSearchReplace_EmptySearchErrors(t *testing.T) {
 	}
 }
 
+// All:true against a CRLF source with a multi-line LF search must replace every
+// occurrence and keep CRLF.
+func TestApplyOpsSearchReplace_CRLFAll(t *testing.T) {
+	source := "A\r\nx\r\nB\r\nA\r\nx\r\nB"
+	got, err := adt.ApplyPatchOps(source, []adt.PatchOp{
+		{Type: "search_replace", Search: "A\nx", Replace: "A\ny", All: true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "A\r\ny\r\nB\r\nA\r\ny\r\nB"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// A replacement that already contains CRLF must not be corrupted into \r\r\n
+// when the source is CRLF (regression guard for the realignment).
+func TestApplyOpsSearchReplace_CRLFReplaceNotDoubled(t *testing.T) {
+	source := "line1\r\nTARGET\r\nline3"
+	got, err := adt.ApplyPatchOps(source, []adt.PatchOp{
+		// replace already uses CRLF; search uses bare LF (single token here).
+		{Type: "search_replace", Search: "TARGET", Replace: "new1\r\nnew2"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "line1\r\nnew1\r\nnew2\r\nline3"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "\r\r") {
+		t.Errorf("replacement CRLF got doubled to \\r\\r\\n: %q", got)
+	}
+}
+
+// Multiple search_replace ops in one call apply in order to the same result.
+func TestApplyOpsSearchReplace_MultipleOps(t *testing.T) {
+	source := "alpha beta gamma"
+	got, err := adt.ApplyPatchOps(source, []adt.PatchOp{
+		{Type: "search_replace", Search: "alpha", Replace: "ALPHA"},
+		{Type: "search_replace", Search: "gamma", Replace: "GAMMA"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "ALPHA beta GAMMA"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// Known limitation (documented in applySearchReplace): a line-op splices content
+// with a bare-LF boundary, so in a CRLF source a following search_replace that
+// spans that boundary is realigned to CRLF and does not match — it errors
+// loudly rather than silently no-op'ing. This test pins that documented
+// behavior so a future change to it is deliberate.
+func TestApplyOpsSearchReplace_SpanningInsertedBoundaryErrors(t *testing.T) {
+	source := "a\r\nb"
+	_, err := adt.ApplyPatchOps(source, []adt.PatchOp{
+		{Type: "insert", AfterLine: 1, Content: "NEW"},                // -> "a\r\nNEW\nb"
+		{Type: "search_replace", Search: "NEW\nb", Replace: "NEW\nB"}, // realigned to "NEW\r\nb", not present
+	})
+	if err == nil {
+		t.Fatal("expected not-found error for a search spanning the bare-LF inserted boundary in a CRLF source")
+	}
+}
+
 func TestApplyOpsMultiple(t *testing.T) {
 	// Two inserts: ops should be sorted descending by after_line so bottom-up application works.
 	source := "line1\nline2\nline3"


### PR DESCRIPTION
## Summary

Closes #69. `ApplyPatchOps` search_replace **silently no-op'd** when the stored SAP source used CRLF (`\r\n`) but the caller's `search` string used bare LF (`\n`): `strings.Replace` found no match, nothing changed, yet the write path still returned `success: true` and issued a fresh ETag — so callers were misled into activating/testing an unchanged source.

`applySearchReplace` (extracted) now:
- **CRLF tolerance:** when the source uses CRLF and the search uses bare LF, realign the search **and** the replacement to CRLF, so the match succeeds and inserted text keeps the source's line-ending style.
- **No silent no-op:** return an error when the search string is **empty** or **not found**, so a search_replace can never succeed while changing nothing.

This addresses both remedies the issue proposed (normalize line endings **and** signal a zero-match), choosing an error for the zero-match case so the caller sees it immediately.

## Test plan

`adt/patch_test.go` (new cases):
- CRLF source + multi-line LF search → replacement applied, result stays CRLF.
- CRLF source + single-line (newline-free) search → still matches.
- search not present → error (message mentions "not found").
- empty search → error.

Existing search_replace tests (matching searches) unchanged. `go test ./...`, `go vet ./...`, `gofmt`, `golangci-lint v2.11.4 --enable dupl,goconst,gocyclo` all clean.

Note: this is the adtler fix; the aibap.mcp `patch_source` tool consumes it after the next adtler bump.