### PR TITLE
fix: repair broken -tags=integration build (undefined ctx since #100)

### DIFF
--- a/adt/classrun_integration_test.go
+++ b/adt/classrun_integration_test.go
@@ -38,6 +38,7 @@ func TestRunClass_Integration(t *testing.T) {
 	for _, sys := range eachSystem(t) {
 		sys := sys
 		t.Run(sys.Name, func(t *testing.T) {
+			ctx := context.Background()
 			if _, err := sys.Client.GetObjectInfo(ctx, classrunClassURI(classrunFixture)); err != nil {
 				var adtErr *adt.ADTError
 				if errors.As(err, &adtErr) && adtErr.StatusCode == 404 {


### PR DESCRIPTION
The `-tags=integration` build of package `adt_test` has been broken since the classrun endpoint merge (#100): `TestRunClass_Integration` references a package-level `ctx` that is declared nowhere, so `go build -tags integration ./adt/...` and `go vet -tags=integration ./adt/...` fail to compile. CI does not build the integration suite (it needs SAP credentials), so it went unnoticed.

Fix: add a local `ctx := context.Background()` inside the `t.Run` closure, matching `TestRunClass_ThrowingClass`. No package-level global (which would shadow the many local `ctx` vars in the other integration tests).

Verified: `go build -tags integration ./adt/...` and `go vet -tags=integration ./adt/...` now compile; `go test ./...` stays green.

Note: this same one-liner is also included in #107 so that branch's integration suite compiles; the identical patch dedupes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)