### PR TITLE
fix(#114): RunClass runs on the long HTTP client with a default deadline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,17 @@ R/3 (ECC) and S/4HANA often behave differently for the same ADT endpoint. Always
 
 The inverse also matters: some operations need a **fresh** session, not a reused one. `RunClass` runs on a single-use isolated session (`freshSession`) because a session that performed the create/set source/activate lifecycle cannot generate a class's runtime load on S/4 (see "Runtime-load generation vs. session reuse" under SAP system differences). If an operation depends on state SAP only generates in a clean session, give it a fresh session instead of reusing the caller's.
 
+### Long-running ABAP execution (two HTTP clients)
+
+The client holds two `*http.Client`s: `http` with a 30-second timeout for ordinary ADT calls, and `httpLong` with no timeout of its own, where the deadline comes from the context (`doReadLong`, `doMutateLong`).
+
+Any endpoint that executes **open-ended ABAP** — currently `RunQuery` (data preview) and `RunClass` (classrun) — must use both halves of the long path:
+
+1. `doMutateLong` / `doReadLong`, because 30 seconds is arbitrary for user-authored ABAP and consumers cannot raise it (`http.Client.Timeout` and the context deadline combine as `min(...)`, and the client fields are unexported), and
+2. `withDefaultDeadline(ctx)`, because the long client imposes no limit at all — without a default deadline a runaway statement hangs the caller forever.
+
+Doing only (1) trades a wrong limit for no limit. The shared default lives in `defaultLongRunTimeout` (5 minutes, just past the usual SAP dialog work-process limit so SAP aborts the step and returns a diagnosable error first); both endpoints reference it so they cannot drift apart. Fixed for `RunClass` in #114.
+
 ## Coding Pitfalls
 
 - **Never use Go backtick (raw) string literals for ABAP source code** in test fixtures. Backtick strings preserve tab indentation from the Go source file.

--- a/adt/classrun.go
+++ b/adt/classrun.go
@@ -21,6 +21,10 @@ type ClassRunClient interface {
 	// endpoint and returns whatever the class writes to the console handler
 	// (out->write(...)). It does not validate that the class exists, is
 	// active, or implements IF_OO_ADT_CLASSRUN — the caller pre-checks that.
+	//
+	// Executing a class is open-ended ABAP, so the run is not capped by the
+	// short HTTP client's 30-second timeout. Pass a context deadline to bound
+	// it; without one, defaultLongRunTimeout applies.
 	RunClass(ctx context.Context, className string) (*ClassRunResult, error)
 }
 
@@ -36,13 +40,24 @@ type ClassRunClient interface {
 // own concern — so an isolated session is consistent with its contract and
 // leaves the caller's session and locks untouched.
 //
+// The POST goes through the LONG-TIMEOUT HTTP client (doMutateLong): running an
+// IF_OO_ADT_CLASSRUN class is arbitrary user-authored ABAP and routinely takes
+// longer than the short client's 30-second cap, which consumers cannot raise
+// (http.Client.Timeout and the context deadline combine as min(...), issue
+// #114). Because that client imposes no limit of its own, a default deadline is
+// applied when the caller supplies none — otherwise a runaway class would hang
+// the caller indefinitely. Both halves are required; see defaultLongRunTimeout.
+//
 // Namespace slashes in className are percent-encoded automatically by
-// doMutate → encodeNamespacePath (triggered by the "//" that results from
+// doMutateLong → encodeNamespacePath (triggered by the "//" that results from
 // appending "/na2/foo" to the base).
 func (c *httpClient) RunClass(ctx context.Context, className string) (*ClassRunResult, error) {
+	ctx, cancel := withDefaultDeadline(ctx)
+	defer cancel()
+
 	fresh := c.freshSession()
 	uri := "/sap/bc/adt/oo/classrun/" + strings.ToLower(className)
-	resp, err := fresh.doMutate(ctx, http.MethodPost, uri, nil,
+	resp, err := fresh.doMutateLong(ctx, http.MethodPost, uri, nil,
 		map[string]string{"Accept": contentTypeTextPlain})
 	if err != nil {
 		return nil, fmt.Errorf("RunClass: %w", err)

--- a/adt/classrun_integration_test.go
+++ b/adt/classrun_integration_test.go
@@ -206,6 +206,112 @@ func TestRunClass_ReactivatedClass_Integration(t *testing.T) {
 	}
 }
 
+// longRunCapSeconds is how long the issue #114 probe class busy-loops before it
+// exits on its own — comfortably past the 30-second short-HTTP-client cap that
+// used to abort RunClass, and short enough to stay well inside the SAP dialog
+// work-process limit.
+const longRunCapSeconds = 45
+
+// longRunClassrunSource returns an IF_OO_ADT_CLASSRUN implementation that busy-
+// loops for capSeconds and then writes "elapsed <n> s". The hard cap means the
+// class terminates by itself even if the client goes away. Built from double-
+// quoted strings (not a Go backtick literal) per the CLAUDE.md ABAP-fixture rule.
+func longRunClassrunSource(className string, capSeconds int) string {
+	l := strings.ToLower(className)
+	return "CLASS " + l + " DEFINITION PUBLIC FINAL CREATE PUBLIC.\n" +
+		"  PUBLIC SECTION.\n" +
+		"    INTERFACES if_oo_adt_classrun.\n" +
+		"  PRIVATE SECTION.\n" +
+		"    CONSTANTS mc_cap_seconds TYPE i VALUE " + fmt.Sprint(capSeconds) + ".\n" +
+		"ENDCLASS.\n\n" +
+		"CLASS " + l + " IMPLEMENTATION.\n" +
+		"  METHOD if_oo_adt_classrun~main.\n" +
+		"    DATA lv_counter TYPE int8.\n" +
+		"    DATA lv_elapsed TYPE p LENGTH 8 DECIMALS 2.\n" +
+		"    GET TIME STAMP FIELD DATA(lv_start).\n" +
+		"    DO.\n" +
+		"      lv_counter = lv_counter + 1.\n" +
+		"      IF lv_counter MOD 5000000 = 0.\n" +
+		"        GET TIME STAMP FIELD DATA(lv_now).\n" +
+		"        lv_elapsed = cl_abap_tstmp=>subtract( tstmp1 = lv_now tstmp2 = lv_start ).\n" +
+		"        IF lv_elapsed >= mc_cap_seconds.\n" +
+		"          EXIT.\n" +
+		"        ENDIF.\n" +
+		"      ENDIF.\n" +
+		"    ENDDO.\n" +
+		"    out->write( |elapsed { lv_elapsed } s| ).\n" +
+		"  ENDMETHOD.\n" +
+		"ENDCLASS.\n"
+}
+
+// TestRunClass_LongRunning_Integration is the issue #114 regression test: a
+// classrun that runs for longRunCapSeconds (45 s) must come back with its
+// console output instead of dying at the 30-second short-HTTP-client cap.
+//
+// Pre-fix, RunClass POSTed through the 30 s client and failed with
+//
+//	Post ".../oo/classrun/...": context deadline exceeded
+//	(Client.Timeout exceeded while awaiting headers)
+//
+// after ~30 s wall clock, while the ABAP work process kept running. Post-fix the
+// POST goes through the long client with the default deadline, so the run
+// completes. The elapsed-time assertion is the actual proof: a pass in under
+// 30 s would mean the class did not really run long, making the test vacuous.
+//
+// The caller passes a plain context.Background() on purpose — the default
+// deadline must be what carries the run.
+func TestRunClass_LongRunning_Integration(t *testing.T) {
+	for _, sys := range eachSystem(t) {
+		sys := sys
+		t.Run(sys.Name, func(t *testing.T) {
+			ctx := context.Background()
+			name := fmt.Sprintf("ZCL_RC114_SLOW_%d", time.Now().UnixNano()%10000000000000)
+			uri := createTmpClassrunClass(t, sys.Client, name)
+
+			lock, err := sys.Client.LockObject(ctx, uri)
+			if err != nil {
+				t.Fatalf("LockObject %s: %v", name, err)
+			}
+			src, err := sys.Client.GetSource(ctx, uri)
+			if err != nil {
+				_ = sys.Client.UnlockObject(ctx, uri, lock)
+				t.Fatalf("GetSource %s: %v", name, err)
+			}
+			if _, err := sys.Client.SetSource(ctx, uri,
+				longRunClassrunSource(name, longRunCapSeconds), lock, "", src.ETag); err != nil {
+				_ = sys.Client.UnlockObject(ctx, uri, lock)
+				t.Fatalf("SetSource %s: %v", name, err)
+			}
+			_ = sys.Client.UnlockObject(ctx, uri, lock)
+			res, err := sys.Client.ActivateObjects(ctx, []string{uri})
+			if err != nil {
+				t.Fatalf("ActivateObjects %s: %v", name, err)
+			}
+			if !res.Success {
+				t.Fatalf("activation of %s failed: %d messages", name, len(res.Messages))
+			}
+
+			start := time.Now()
+			result, err := sys.Client.RunClass(ctx, name)
+			elapsed := time.Since(start)
+			if err != nil {
+				t.Fatalf("%s: RunClass of the %d s class failed after %v (issue #114 — capped by the short HTTP client?): %v",
+					sys.Name, longRunCapSeconds, elapsed, err)
+			}
+			if !strings.Contains(result.ConsoleOutput, "elapsed") {
+				t.Errorf("%s: console output %q does not contain the expected \"elapsed ... s\" line",
+					sys.Name, strings.TrimSpace(result.ConsoleOutput))
+			}
+			if elapsed < 30*time.Second {
+				t.Errorf("%s: RunClass returned after only %v — the class did not run past the old 30 s cap, so this test proves nothing",
+					sys.Name, elapsed)
+			}
+			t.Logf("%s: %d s classrun returned after %v: %q",
+				sys.Name, longRunCapSeconds, elapsed, strings.TrimSpace(result.ConsoleOutput))
+		})
+	}
+}
+
 // TestRunClass_ThrowingClass confirms how an uncaught runtime exception in
 // main() is signalled — spec open verification point #1. Verified against
 // CL_OO_ADT_RES_CLASSRUN: main() runs inside a TRY that catches only

--- a/adt/classrun_timeout_internal_test.go
+++ b/adt/classrun_timeout_internal_test.go
@@ -1,0 +1,256 @@
+package adt
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sapmcpconfig "github.com/Hochfrequenz/sap-mcp-config"
+)
+
+// Issue #114: RunClass used to POST through the short (30-second) HTTP client,
+// so any classrun running longer than 30 s failed with "Client.Timeout exceeded
+// while awaiting headers" even though the ABAP work process was still running.
+// Consumers could not work around it: http.Client.Timeout and the context
+// deadline combine as min(Timeout, ctx), and the client fields are unexported.
+//
+// The tests below are internal (package adt) on purpose: the regression is about
+// WHICH *http.Client carries the request, and the only way to observe that
+// without sleeping past 30 s of real time is to shrink the short client's
+// timeout to milliseconds and check whether the request survives. A request that
+// survives a 30-ms short-client cap cannot be running on the short client.
+const (
+	// discoveryPath is the CSRF preflight endpoint (fast in these tests).
+	discoveryPath = "/sap/bc/adt/discovery"
+	// dataPreviewPath is the RunQuery endpoint.
+	dataPreviewPath = "/sap/bc/adt/datapreview/freestyle"
+	// tinyShortTimeout stands in for the production 30 s short-client cap.
+	tinyShortTimeout = 30 * time.Millisecond
+	// slowResponse is comfortably longer than tinyShortTimeout but short enough
+	// to keep the unit suite fast. It stands in for a 45 s classrun.
+	slowResponse = 250 * time.Millisecond
+	// emptyTableData is a minimal, parseable data preview response for RunQuery.
+	emptyTableData = `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<tableData><totalRows>0</totalRows><queryExecutionTime>1.0</queryExecutionTime></tableData>`
+)
+
+// slowServer serves an instant CSRF preflight and delays every other response by
+// delay. The classrun endpoint answers text/plain, the data preview endpoint
+// answers a minimal tableData document, so the same server drives both RunClass
+// and RunQuery.
+func slowServer(delay time.Duration) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == discoveryPath {
+			w.Header().Set("X-CSRF-Token", "token")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		select {
+		case <-time.After(delay):
+		case <-r.Context().Done():
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, dataPreviewPath) {
+			w.Header().Set("Content-Type", "application/vnd.sap.adt.datapreview.table.v1+xml")
+			_, _ = w.Write([]byte(emptyTableData))
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte("elapsed 45.00 s\n"))
+	}))
+}
+
+// shortCappedClient returns a client whose SHORT http client is capped at
+// tinyShortTimeout while the long client keeps its production configuration
+// (no timeout of its own, deadline supplied by the context). Any request that
+// completes on such a client took the long path.
+func shortCappedClient(t *testing.T, host string) *httpClient {
+	t.Helper()
+	c, ok := NewClient(sapmcpconfig.SAPSystem{Host: host, User: "U", Password: "P", Client: "100"}).(*httpClient)
+	if !ok {
+		t.Fatalf("NewClient did not return *httpClient")
+	}
+	c.http.Timeout = tinyShortTimeout
+	return c
+}
+
+// TestRunClass_NotCappedByShortClient is the issue #114 regression guard: the
+// classrun POST must not run on the short HTTP client. With the short client
+// capped at 30 ms and the server answering after 250 ms, the pre-fix code
+// (doMutate) fails with "Client.Timeout exceeded"; the fixed code (doMutateLong)
+// returns the console output.
+func TestRunClass_NotCappedByShortClient(t *testing.T) {
+	srv := slowServer(slowResponse)
+	defer srv.Close()
+	c := shortCappedClient(t, srv.URL)
+
+	result, err := c.RunClass(context.Background(), "ZCL_SLOW")
+	if err != nil {
+		t.Fatalf("RunClass was capped by the short HTTP client: %v", err)
+	}
+	if result.ConsoleOutput != "elapsed 45.00 s\n" {
+		t.Errorf("ConsoleOutput: got %q, want %q", result.ConsoleOutput, "elapsed 45.00 s\n")
+	}
+}
+
+// TestRunClass_HonoursCallerDeadline guards the other direction: switching to
+// the unlimited client must not remove the limit altogether. A caller-supplied
+// deadline shorter than the server's response time must abort the run, and the
+// caller's deadline must win over defaultLongRunTimeout.
+func TestRunClass_HonoursCallerDeadline(t *testing.T) {
+	srv := slowServer(3 * time.Second)
+	defer srv.Close()
+	c := shortCappedClient(t, srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := c.RunClass(ctx, "ZCL_SLOW")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected the caller's 100 ms deadline to abort RunClass, got nil error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error: got %v, want a context.DeadlineExceeded", err)
+	}
+	if elapsed > time.Second {
+		t.Errorf("RunClass took %v — the caller's deadline was not honoured promptly", elapsed)
+	}
+}
+
+// TestRunClass_DefaultDeadlineApplies verifies that a context WITHOUT a deadline
+// still gets one. The long HTTP client has no timeout of its own, so without the
+// default a runaway classrun would hang the caller forever.
+func TestRunClass_DefaultDeadlineApplies(t *testing.T) {
+	srv := slowServer(10 * time.Second)
+	defer srv.Close()
+	c := shortCappedClient(t, srv.URL)
+
+	restore := defaultLongRunTimeout
+	defaultLongRunTimeout = 150 * time.Millisecond
+	defer func() { defaultLongRunTimeout = restore }()
+
+	start := time.Now()
+	_, err := c.RunClass(context.Background(), "ZCL_SLOW") // no deadline
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected the default deadline to abort RunClass, got nil error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error: got %v, want a context.DeadlineExceeded", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("RunClass ran for %v — the default deadline was not applied", elapsed)
+	}
+}
+
+// TestWithDefaultDeadline covers the helper directly: a caller deadline is left
+// untouched, an unbounded context receives defaultLongRunTimeout.
+func TestWithDefaultDeadline(t *testing.T) {
+	restore := defaultLongRunTimeout
+	defaultLongRunTimeout = time.Hour
+	defer func() { defaultLongRunTimeout = restore }()
+
+	callerDeadline := time.Now().Add(time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), callerDeadline)
+	defer cancel()
+	got, cancel2 := withDefaultDeadline(ctx)
+	defer cancel2()
+	deadline, ok := got.Deadline()
+	if !ok || !deadline.Equal(callerDeadline) {
+		t.Errorf("caller deadline: got (%v, %v), want %v", deadline, ok, callerDeadline)
+	}
+
+	got, cancel3 := withDefaultDeadline(context.Background())
+	defer cancel3()
+	deadline, ok = got.Deadline()
+	if !ok {
+		t.Fatal("unbounded context got no deadline")
+	}
+	if remaining := time.Until(deadline); remaining < 55*time.Minute {
+		t.Errorf("default deadline: %v remaining, want ~1h (defaultLongRunTimeout)", remaining)
+	}
+}
+
+// TestFreshSession_PreservesLongClient pins the assumption RunClass relies on:
+// the single-use fresh session must carry the same long-client configuration as
+// its parent, or RunClass would silently fall back to a capped client via the
+// fresh-session path. The fresh session's cookie jar must still be its own —
+// that isolation is what the issue #106 fix depends on.
+func TestFreshSession_PreservesLongClient(t *testing.T) {
+	parent, ok := NewClient(sapmcpconfig.SAPSystem{Host: "https://example.invalid", Client: "100"}).(*httpClient)
+	if !ok {
+		t.Fatalf("NewClient did not return *httpClient")
+	}
+	fresh := parent.freshSession()
+
+	if fresh.httpLong == nil {
+		t.Fatal("fresh session has no long HTTP client")
+	}
+	if fresh.httpLong.Timeout != parent.httpLong.Timeout {
+		t.Errorf("fresh httpLong.Timeout: got %v, want %v (parent's)",
+			fresh.httpLong.Timeout, parent.httpLong.Timeout)
+	}
+	if fresh.httpLong.Timeout != 0 {
+		t.Errorf("fresh httpLong.Timeout: got %v, want 0 (deadline comes from the context)",
+			fresh.httpLong.Timeout)
+	}
+	if fresh.httpLong.Transport != parent.httpLong.Transport {
+		t.Error("fresh httpLong does not reuse the parent's transport")
+	}
+	if fresh.httpLong.Jar == nil {
+		t.Fatal("fresh httpLong has no cookie jar")
+	}
+	if fresh.httpLong.Jar == parent.httpLong.Jar {
+		t.Error("fresh httpLong reuses the parent's cookie jar — session isolation lost (#106)")
+	}
+	if fresh.httpLong.Jar != fresh.http.Jar {
+		t.Error("fresh session's short and long clients use different cookie jars")
+	}
+}
+
+// TestRunQueryAndRunClass_ShareLongPath is the drift guard required by issue
+// #114: both endpoints execute open-ended ABAP, so both must route through the
+// long HTTP client AND share one default deadline. The two assertions below fail
+// if either endpoint is changed in isolation.
+func TestRunQueryAndRunClass_ShareLongPath(t *testing.T) {
+	run := func(t *testing.T, c *httpClient) (classErr, queryErr error) {
+		t.Helper()
+		_, classErr = c.RunClass(context.Background(), "ZCL_SLOW")
+		_, queryErr = c.RunQuery(context.Background(), "SELECT * FROM T000", 1)
+		return classErr, queryErr
+	}
+
+	t.Run("both bypass the short client cap", func(t *testing.T) {
+		srv := slowServer(slowResponse)
+		defer srv.Close()
+		classErr, queryErr := run(t, shortCappedClient(t, srv.URL))
+		if classErr != nil {
+			t.Errorf("RunClass ran on the short client: %v", classErr)
+		}
+		if queryErr != nil {
+			t.Errorf("RunQuery ran on the short client: %v", queryErr)
+		}
+	})
+
+	t.Run("both apply the same default deadline", func(t *testing.T) {
+		srv := slowServer(10 * time.Second)
+		defer srv.Close()
+		restore := defaultLongRunTimeout
+		defaultLongRunTimeout = 150 * time.Millisecond
+		defer func() { defaultLongRunTimeout = restore }()
+
+		classErr, queryErr := run(t, shortCappedClient(t, srv.URL))
+		if !errors.Is(classErr, context.DeadlineExceeded) {
+			t.Errorf("RunClass: got %v, want context.DeadlineExceeded from the shared default", classErr)
+		}
+		if !errors.Is(queryErr, context.DeadlineExceeded) {
+			t.Errorf("RunQuery: got %v, want context.DeadlineExceeded from the shared default", queryErr)
+		}
+	})
+}

--- a/adt/classrun_timeout_internal_test.go
+++ b/adt/classrun_timeout_internal_test.go
@@ -23,6 +23,10 @@ import (
 // without sleeping past 30 s of real time is to shrink the short client's
 // timeout to milliseconds and check whether the request survives. A request that
 // survives a 30-ms short-client cap cannot be running on the short client.
+//
+// Several tests here temporarily swap the package-level defaultLongRunTimeout
+// and restore it in a defer, so they must NOT call t.Parallel() (nothing in
+// package adt does today).
 const (
 	// discoveryPath is the CSRF preflight endpoint (fast in these tests).
 	discoveryPath = "/sap/bc/adt/discovery"
@@ -33,6 +37,12 @@ const (
 	// slowResponse is comfortably longer than tinyShortTimeout but short enough
 	// to keep the unit suite fast. It stands in for a 45 s classrun.
 	slowResponse = 250 * time.Millisecond
+	// stalledResponse stands in for a classrun that never returns in time — any
+	// value far past tinyDeadline does; slowServer releases the sleeping handler
+	// at teardown, so this delay is not paid in wall-clock time.
+	stalledResponse = 30 * time.Second
+	// tinyDeadline is the caller/default deadline used against stalledResponse.
+	tinyDeadline = 150 * time.Millisecond
 	// emptyTableData is a minimal, parseable data preview response for RunQuery.
 	emptyTableData = `<?xml version="1.0" encoding="UTF-8"?>` +
 		`<tableData><totalRows>0</totalRows><queryExecutionTime>1.0</queryExecutionTime></tableData>`
@@ -42,8 +52,18 @@ const (
 // delay. The classrun endpoint answers text/plain, the data preview endpoint
 // answers a minimal tableData document, so the same server drives both RunClass
 // and RunQuery.
-func slowServer(delay time.Duration) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//
+// Shutdown is registered with t.Cleanup and closes a stop channel BEFORE
+// srv.Close(): httptest.Server.Close waits for in-flight handlers, and a handler
+// aborted mid-sleep cannot be relied on to observe r.Context() cancellation
+// (net/http only notices the closed connection via its background read, which a
+// sleeping handler may outlive). Without the stop channel, teardown blocks for
+// the remaining delay — measurably so, and Go prints "httptest.Server blocked in
+// Close after 5 seconds". Callers must therefore NOT defer srv.Close() themselves.
+func slowServer(t *testing.T, delay time.Duration) *httptest.Server {
+	t.Helper()
+	stop := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == discoveryPath {
 			w.Header().Set("X-CSRF-Token", "token")
 			w.WriteHeader(http.StatusOK)
@@ -52,6 +72,8 @@ func slowServer(delay time.Duration) *httptest.Server {
 		select {
 		case <-time.After(delay):
 		case <-r.Context().Done():
+			return
+		case <-stop:
 			return
 		}
 		if strings.HasPrefix(r.URL.Path, dataPreviewPath) {
@@ -62,6 +84,11 @@ func slowServer(delay time.Duration) *httptest.Server {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		_, _ = w.Write([]byte("elapsed 45.00 s\n"))
 	}))
+	t.Cleanup(func() {
+		close(stop)
+		srv.Close()
+	})
+	return srv
 }
 
 // shortCappedClient returns a client whose SHORT http client is capped at
@@ -84,8 +111,7 @@ func shortCappedClient(t *testing.T, host string) *httpClient {
 // (doMutate) fails with "Client.Timeout exceeded"; the fixed code (doMutateLong)
 // returns the console output.
 func TestRunClass_NotCappedByShortClient(t *testing.T) {
-	srv := slowServer(slowResponse)
-	defer srv.Close()
+	srv := slowServer(t, slowResponse)
 	c := shortCappedClient(t, srv.URL)
 
 	result, err := c.RunClass(context.Background(), "ZCL_SLOW")
@@ -102,18 +128,17 @@ func TestRunClass_NotCappedByShortClient(t *testing.T) {
 // deadline shorter than the server's response time must abort the run, and the
 // caller's deadline must win over defaultLongRunTimeout.
 func TestRunClass_HonoursCallerDeadline(t *testing.T) {
-	srv := slowServer(3 * time.Second)
-	defer srv.Close()
+	srv := slowServer(t, stalledResponse)
 	c := shortCappedClient(t, srv.URL)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), tinyDeadline)
 	defer cancel()
 
 	start := time.Now()
 	_, err := c.RunClass(ctx, "ZCL_SLOW")
 	elapsed := time.Since(start)
 	if err == nil {
-		t.Fatal("expected the caller's 100 ms deadline to abort RunClass, got nil error")
+		t.Fatalf("expected the caller's %v deadline to abort RunClass, got nil error", tinyDeadline)
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("error: got %v, want a context.DeadlineExceeded", err)
@@ -127,12 +152,11 @@ func TestRunClass_HonoursCallerDeadline(t *testing.T) {
 // still gets one. The long HTTP client has no timeout of its own, so without the
 // default a runaway classrun would hang the caller forever.
 func TestRunClass_DefaultDeadlineApplies(t *testing.T) {
-	srv := slowServer(10 * time.Second)
-	defer srv.Close()
+	srv := slowServer(t, stalledResponse)
 	c := shortCappedClient(t, srv.URL)
 
 	restore := defaultLongRunTimeout
-	defaultLongRunTimeout = 150 * time.Millisecond
+	defaultLongRunTimeout = tinyDeadline
 	defer func() { defaultLongRunTimeout = restore }()
 
 	start := time.Now()
@@ -144,7 +168,7 @@ func TestRunClass_DefaultDeadlineApplies(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("error: got %v, want a context.DeadlineExceeded", err)
 	}
-	if elapsed > 3*time.Second {
+	if elapsed > time.Second {
 		t.Errorf("RunClass ran for %v — the default deadline was not applied", elapsed)
 	}
 }
@@ -227,8 +251,7 @@ func TestRunQueryAndRunClass_ShareLongPath(t *testing.T) {
 	}
 
 	t.Run("both bypass the short client cap", func(t *testing.T) {
-		srv := slowServer(slowResponse)
-		defer srv.Close()
+		srv := slowServer(t, slowResponse)
 		classErr, queryErr := run(t, shortCappedClient(t, srv.URL))
 		if classErr != nil {
 			t.Errorf("RunClass ran on the short client: %v", classErr)
@@ -239,10 +262,9 @@ func TestRunQueryAndRunClass_ShareLongPath(t *testing.T) {
 	})
 
 	t.Run("both apply the same default deadline", func(t *testing.T) {
-		srv := slowServer(10 * time.Second)
-		defer srv.Close()
+		srv := slowServer(t, stalledResponse)
 		restore := defaultLongRunTimeout
-		defaultLongRunTimeout = 150 * time.Millisecond
+		defaultLongRunTimeout = tinyDeadline
 		defer func() { defaultLongRunTimeout = restore }()
 
 		classErr, queryErr := run(t, shortCappedClient(t, srv.URL))

--- a/adt/client.go
+++ b/adt/client.go
@@ -513,6 +513,30 @@ func (c *httpClient) doMutate(ctx context.Context, method, path string, body io.
 	return c.doMutateWith(ctx, c.http, method, path, body, headers)
 }
 
+// defaultLongRunTimeout is the deadline applied by withDefaultDeadline to
+// open-ended ABAP execution (RunQuery, RunClass) when the caller's context
+// carries none. The long-timeout HTTP client imposes no limit of its own, so
+// without this a runaway statement would hang the calling goroutine forever.
+//
+// Five minutes is chosen to sit just past the SAP dialog work-process limit
+// (rdisp/max_wprun_time, commonly 300-600 s): SAP aborts the step itself and
+// returns a diagnosable error, which is more useful than the client giving up
+// first. Both RunQuery and RunClass share this value deliberately — one default
+// for "open-ended ABAP" keeps the two endpoints from drifting apart.
+//
+// A variable rather than a constant so tests can shorten it.
+var defaultLongRunTimeout = 5 * time.Minute
+
+// withDefaultDeadline returns ctx and a cancel func to defer. If ctx already
+// carries a deadline, the caller's deadline wins and cancel is a no-op;
+// otherwise defaultLongRunTimeout is applied.
+func withDefaultDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, defaultLongRunTimeout)
+}
+
 // doMutateLong is like doMutate but uses the long-timeout HTTP client (httpLong).
 // Intended for long-running queries where the caller controls the deadline via context.
 func (c *httpClient) doMutateLong(ctx context.Context, method, path string, body io.Reader, headers map[string]string) (*http.Response, error) {

--- a/adt/query.go
+++ b/adt/query.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Hochfrequenz/adtler/adt/adtxml"
 )
@@ -31,7 +30,8 @@ func validateSelectOnly(sql string) error {
 
 // RunQuery executes a read-only SQL query via the ADT data preview endpoint.
 // Only single SELECT statements are allowed; anything else is rejected.
-// If the caller's context has no deadline, a 5-minute timeout is applied.
+// The request goes through the long-timeout HTTP client; if the caller's context
+// has no deadline, defaultLongRunTimeout is applied.
 func (c *httpClient) RunQuery(ctx context.Context, sql string, maxRows int) (*QueryResult, error) {
 	trimmed := strings.TrimSpace(sql)
 	if err := validateSelectOnly(trimmed); err != nil {
@@ -43,11 +43,8 @@ func (c *httpClient) RunQuery(ctx context.Context, sql string, maxRows int) (*Qu
 	}
 
 	// Apply default timeout if caller didn't set one.
-	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 5*time.Minute)
-		defer cancel()
-	}
+	ctx, cancel := withDefaultDeadline(ctx)
+	defer cancel()
 
 	path := fmt.Sprintf("/sap/bc/adt/datapreview/freestyle?rowNumber=%d", maxRows)
 	headers := map[string]string{


### PR DESCRIPTION
Fixes #114. Consumer issue: Hochfrequenz/aibap.mcp#465

## What was wrong

`RunClass` issued its POST through the 30-second HTTP client, even though executing an
`IF_OO_ADT_CLASSRUN` class is arbitrary user-authored ABAP. Anything running longer than 30 s
failed with `Client.Timeout exceeded while awaiting headers` while the ABAP work process kept
going. Consumers could not work around it: `http.Client.Timeout` and the context deadline
combine as `min(Timeout, ctx)`, and the client fields are unexported.

## What changed

`RunClass` now mirrors `RunQuery` in full — both halves, as the issue requires:

1. the POST goes through `doMutateLong` (the client with no cap of its own), and
2. `withDefaultDeadline(ctx)` applies a default deadline when the caller supplies none.

Doing only (1) would trade a wrong limit for **no** limit and let a runaway classrun hang the
caller indefinitely.

The shared default is hoisted into `defaultLongRunTimeout` behind the new `withDefaultDeadline`
helper, which `RunQuery` now uses as well — one default for "open-ended ABAP", so the two
endpoints cannot drift apart again.

### The default: 5 minutes, deliberately

The issue asked for a decision rather than a reflex copy of `RunQuery`'s 5 minutes. 5 minutes
it is, on these grounds:

- classrun executes in a **dialog work process**, so SAP enforces `rdisp/max_wprun_time`
  (commonly 300-600 s) itself. A client deadline sitting just past that lets SAP abort the step
  and return a diagnosable error, which beats the client bailing out first and leaving the work
  process running — exactly the failure mode #114 is about.
- A shorter default (say 60 s) would re-create the reported bug for legitimately slow classruns,
  just at a different number.
- Callers who want tighter control pass a context deadline; theirs always wins.
- One shared value for both open-ended-ABAP endpoints is the drift guard the issue asked for.

## Tests

`adt/classrun_timeout_internal_test.go` is an internal (`package adt`) test on purpose: the
regression is about *which* `*http.Client` carries the request, and the only way to observe that
without sleeping 30+ s of real time is to shrink the short client's timeout to milliseconds. A
request that survives a 30 ms short-client cap cannot be on the short client.

| Test | Guards |
|---|---|
| `TestRunClass_NotCappedByShortClient` | the actual regression — verified to FAIL on the pre-fix code (`Client.Timeout exceeded`) |
| `TestRunClass_HonoursCallerDeadline` | the limit was not removed; caller deadline wins |
| `TestRunClass_DefaultDeadlineApplies` | a context without a deadline still gets one |
| `TestWithDefaultDeadline` | the helper itself, both branches |
| `TestFreshSession_PreservesLongClient` | `freshSession` keeps the long-client config (not assumed) and still gets its own cookie jar (#106 isolation) |
| `TestRunQueryAndRunClass_ShareLongPath` | drift guard: both route through the long client AND share one default — verified to FAIL on the pre-fix code |

Integration: `TestRunClass_LongRunning_Integration` creates the issue's 45-second busy-loop class
in `$TMP` on every whitelisted system, runs it with a plain `context.Background()` (so the
default deadline is what carries the run), and asserts both the console output and
`elapsed >= 30s` — a pass in under 30 s would mean the class never ran long enough to prove
anything. The probe class caps itself, so it terminates even if the client goes away, and the
fixture is deleted in cleanup.

## Verification

- `go test ./...` — pass
- `go build ./...`, `go vet ./...` — pass
- `go build -tags integration ./adt/...`, `go vet -tags integration ./adt/...` — pass
- `golangci-lint run --enable dupl,goconst,gocyclo ./...` — 0 issues
- Real-SAP integration test still outstanding (`needs:integration-test`)

Also documents the two-HTTP-client rule in CLAUDE.md so the next open-ended-ABAP endpoint gets
both halves from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
